### PR TITLE
fix: disable pdf reader text selection

### DIFF
--- a/lib/pages/reader/pdf_reader/pdf_reader.dart
+++ b/lib/pages/reader/pdf_reader/pdf_reader.dart
@@ -115,6 +115,9 @@ class PdfReader extends HookConsumerWidget {
                 sourceName: chapterId.toString(),
                 initialPageNumber: readerState.initialPage + 1,
                 params: PdfViewerParams(
+                  textSelectionParams: const PdfTextSelectionParams(
+                    enabled: false,
+                  ),
                   onViewerReady: (document, controller) async {
                     toc.value = await document.loadOutline();
                     defaultZoom.value = controller.currentZoom;


### PR DESCRIPTION
appears on images too as a context menu on long press, and cannot be dismissed due to the overlay intercepting taps