### PR TITLE
fix: do not wait for timeout if user is present on startup

### DIFF
--- a/lib/riverpod/providers/auth.dart
+++ b/lib/riverpod/providers/auth.dart
@@ -31,6 +31,8 @@ class CurrentUser extends _$CurrentUser {
     final apiKey = ref.watch(apiKeyProvider);
     if (apiKey == null || apiKey.isEmpty) throw NoCredentialsException();
 
+    if (state.hasValue) state = AsyncData(state.value!);
+
     try {
       final client = ref.watch(restClientProvider);
       final res = await client.apiPluginAuthenticatePost(


### PR DESCRIPTION
Starting up the app while offline would mean waiting multiple seconds for the multiple retries to fetch the user to fail. The refresh now happens in the background while the stored user is made available immediately.