### PR TITLE
feat: add vertical reader zoom gestures

### DIFF
--- a/lib/pages/reader/image_reader/vertical_continuous_reader.dart
+++ b/lib/pages/reader/image_reader/vertical_continuous_reader.dart
@@ -4,6 +4,8 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/models/image_model.dart';
+import 'package:kover/pages/reader/image_reader/vertical_reader_gesture_controller.dart';
+import 'package:kover/pages/reader/image_reader/zoomable_vertical_scroll_view.dart';
 import 'package:kover/riverpod/providers/book.dart';
 import 'package:kover/riverpod/providers/reader/image_vertical_reader.dart';
 import 'package:kover/riverpod/providers/reader/reader_navigation.dart';
@@ -99,10 +101,15 @@ class VerticalContinuousReader extends HookConsumerWidget {
         return HookConsumer(
           builder: (context, ref, _) {
             final scrollController = useScrollController();
+            final gestureController = useMemoized(
+              VerticalReaderGestureController.new,
+            );
             final observerController = useSliverObserverController(
               controller: scrollController,
               initialIndex: nav.currentPage,
             );
+
+            useEffect(() => gestureController.dispose, [gestureController]);
 
             /// Emit last-page progress when scrolled to bottom edge.
             void handleScrollEnd() {
@@ -164,45 +171,59 @@ class VerticalContinuousReader extends HookConsumerWidget {
                     currentPage: nav.currentPage,
                   ),
                 ),
-                SliverViewObserver(
-                  controller: observerController,
-                  onObserve: (ObserveModel model) {
-                    if (model is! ListViewObserveModel) return;
+                ZoomableVerticalScrollView(
+                  scrollController: scrollController,
+                  gestureController: gestureController,
+                  child: SliverViewObserver(
+                    controller: observerController,
+                    onObserve: (ObserveModel model) {
+                      if (model is! ListViewObserveModel) return;
 
-                    final firstVisibleIndex = model.firstChild?.index;
-                    if (firstVisibleIndex == null) return;
+                      final firstVisibleIndex = model.firstChild?.index;
+                      if (firstVisibleIndex == null) return;
 
-                    ref
-                        .read(navProvider.notifier)
-                        .jumpToPage(firstVisibleIndex, fromObserver: true);
-                  },
-                  child: CustomScrollView(
-                    controller: scrollController,
-                    scrollCacheExtent: const ScrollCacheExtent.viewport(5),
-                    scrollBehavior: ScrollConfiguration.of(context).copyWith(
-                      scrollbars: false,
-                    ),
-                    slivers: [
-                      SliverSafeArea(
-                        sliver: SliverPadding(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: settings.verticalReaderPadding,
-                          ),
-                          sliver: SliverList.separated(
-                            itemCount: nav.totalPages,
-
-                            itemBuilder: (context, index) =>
-                                _VerticalReaderItem(
-                                  chapterId: chapterId,
-                                  seriesId: seriesId,
-                                  page: index,
-                                ),
-                            separatorBuilder: (context, index) =>
-                                SizedBox(height: settings.verticalReaderGap),
-                          ),
-                        ),
+                      ref
+                          .read(navProvider.notifier)
+                          .jumpToPage(firstVisibleIndex, fromObserver: true);
+                    },
+                    child: CustomScrollView(
+                      controller: scrollController,
+                      scrollCacheExtent: const ScrollCacheExtent.viewport(5),
+                      scrollBehavior: ScrollConfiguration.of(context).copyWith(
+                        scrollbars: false,
                       ),
-                    ],
+                      slivers: [
+                        AnimatedBuilder(
+                          animation: gestureController,
+                          builder: (context, _) {
+                            return SliverSafeArea(
+                              sliver: SliverPadding(
+                                padding: EdgeInsets.fromLTRB(
+                                  settings.verticalReaderPadding,
+                                  gestureController.verticalScrollPadding,
+                                  settings.verticalReaderPadding,
+                                  gestureController.verticalScrollPadding,
+                                ),
+                                sliver: SliverList.separated(
+                                  itemCount: nav.totalPages,
+
+                                  itemBuilder: (context, index) =>
+                                      _VerticalReaderItem(
+                                        chapterId: chapterId,
+                                        seriesId: seriesId,
+                                        page: index,
+                                      ),
+                                  separatorBuilder: (context, index) =>
+                                      SizedBox(
+                                        height: settings.verticalReaderGap,
+                                      ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ],

--- a/lib/pages/reader/image_reader/vertical_continuous_reader.dart
+++ b/lib/pages/reader/image_reader/vertical_continuous_reader.dart
@@ -198,11 +198,10 @@ class VerticalContinuousReader extends HookConsumerWidget {
                           builder: (context, _) {
                             return SliverSafeArea(
                               sliver: SliverPadding(
-                                padding: EdgeInsets.fromLTRB(
-                                  settings.verticalReaderPadding,
-                                  gestureController.verticalScrollPadding,
-                                  settings.verticalReaderPadding,
-                                  gestureController.verticalScrollPadding,
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: settings.verticalReaderPadding,
+                                  vertical:
+                                      gestureController.verticalScrollPadding,
                                 ),
                                 sliver: SliverList.separated(
                                   itemCount: nav.totalPages,

--- a/lib/pages/reader/image_reader/vertical_reader_gesture_controller.dart
+++ b/lib/pages/reader/image_reader/vertical_reader_gesture_controller.dart
@@ -1,0 +1,94 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class VerticalReaderGestureController extends ChangeNotifier {
+  static const double defaultMinScale = 1.0;
+  static const double defaultMaxScale = 4.0;
+
+  final double minScale;
+  final double maxScale;
+
+  VerticalReaderGestureController({
+    this.minScale = defaultMinScale,
+    this.maxScale = defaultMaxScale,
+  }) : assert(minScale > 0),
+       assert(maxScale >= minScale),
+       _scale = minScale;
+
+  Size _viewportSize = Size.zero;
+  double _scale;
+  double _horizontalTranslation = 0.0;
+
+  double get scale => _scale;
+  Offset get translation => Offset(_horizontalTranslation, 0.0);
+  double get verticalScrollPadding =>
+      _viewportSize.height * (_scale - minScale) / (2 * _scale);
+
+  void configureViewport(Size viewportSize) {
+    if (_viewportSize == viewportSize) return;
+
+    _viewportSize = viewportSize;
+    _horizontalTranslation = _clampHorizontalTranslation(
+      _horizontalTranslation,
+    );
+    notifyListeners();
+  }
+
+  void panHorizontally(double delta) {
+    final nextTranslation = _clampHorizontalTranslation(
+      _horizontalTranslation + delta,
+    );
+    if (nextTranslation != _horizontalTranslation) {
+      _horizontalTranslation = nextTranslation;
+      notifyListeners();
+    }
+  }
+
+  double visualScrollOffset(double scrollOffset) => _scale * scrollOffset;
+
+  double zoomViewport({
+    required double scaleFactor,
+    required Offset focalPoint,
+    required Offset focalPointDelta,
+    required double visualScrollOffset,
+  }) {
+    if (!scaleFactor.isFinite || scaleFactor <= 0) {
+      return visualScrollOffset;
+    }
+
+    final nextScale = (_scale * scaleFactor)
+        .clamp(minScale, maxScale)
+        .toDouble();
+    final appliedFactor = nextScale / _scale;
+    final previousFocalPoint = focalPoint - focalPointDelta;
+    final viewportCenter = _viewportSize.center(Offset.zero);
+    final nextHorizontalTranslation = _clampHorizontalTranslation(
+      focalPointDelta.dx +
+          _horizontalTranslation * appliedFactor +
+          (previousFocalPoint.dx - viewportCenter.dx) * (1 - appliedFactor),
+      scale: nextScale,
+    );
+
+    if (_scale != nextScale ||
+        _horizontalTranslation != nextHorizontalTranslation) {
+      _scale = nextScale;
+      _horizontalTranslation = nextHorizontalTranslation;
+      notifyListeners();
+    }
+
+    return appliedFactor *
+            (visualScrollOffset + previousFocalPoint.dy - viewportCenter.dy) +
+        viewportCenter.dy -
+        focalPoint.dy;
+  }
+
+  double _clampHorizontalTranslation(double translation, {double? scale}) {
+    final effectiveScale = scale ?? _scale;
+    final overflow = math.max(
+      0.0,
+      (_viewportSize.width * effectiveScale - _viewportSize.width) / 2,
+    );
+    return translation.clamp(-overflow, overflow).toDouble();
+  }
+}

--- a/lib/pages/reader/image_reader/vertical_reader_gesture_controller.dart
+++ b/lib/pages/reader/image_reader/vertical_reader_gesture_controller.dart
@@ -3,18 +3,10 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 class VerticalReaderGestureController extends ChangeNotifier {
-  static const double defaultMinScale = 1.0;
-  static const double defaultMaxScale = 4.0;
+  static const double _minScale = 1.0;
+  static const double _maxScale = 4.0;
 
-  final double minScale;
-  final double maxScale;
-
-  VerticalReaderGestureController({
-    this.minScale = defaultMinScale,
-    this.maxScale = defaultMaxScale,
-  }) : assert(minScale > 0),
-       assert(maxScale >= minScale),
-       _scale = minScale;
+  VerticalReaderGestureController() : _scale = _minScale;
 
   Size _viewportSize = Size.zero;
   double _scale;
@@ -23,7 +15,7 @@ class VerticalReaderGestureController extends ChangeNotifier {
   double get scale => _scale;
   Offset get translation => Offset(_horizontalTranslation, 0.0);
   double get verticalScrollPadding =>
-      _viewportSize.height * (_scale - minScale) / (2 * _scale);
+      _viewportSize.height * (_scale - _minScale) / (2 * _scale);
 
   void configureViewport(Size viewportSize) {
     if (_viewportSize == viewportSize) return;
@@ -58,7 +50,7 @@ class VerticalReaderGestureController extends ChangeNotifier {
     }
 
     final nextScale = (_scale * scaleFactor)
-        .clamp(minScale, maxScale)
+        .clamp(_minScale, _maxScale)
         .toDouble();
     final appliedFactor = nextScale / _scale;
     final previousFocalPoint = focalPoint - focalPointDelta;

--- a/lib/pages/reader/image_reader/zoomable_vertical_scroll_view.dart
+++ b/lib/pages/reader/image_reader/zoomable_vertical_scroll_view.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:kover/pages/reader/image_reader/vertical_reader_gesture_controller.dart';
+
+class ZoomableVerticalScrollView extends HookWidget {
+  final ScrollController scrollController;
+  final VerticalReaderGestureController gestureController;
+  final Widget child;
+
+  const ZoomableVerticalScrollView({
+    super.key,
+    required this.scrollController,
+    required this.gestureController,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final gestureActive = useRef(false);
+    final gestureIncludedPinch = useRef(false);
+    final scrolledDuringGesture = useRef(false);
+    final lastPointerCount = useRef(0);
+    final lastScale = useRef(1.0);
+    final lastFocalPoint = useRef(Offset.zero);
+    final scheduledViewportSize = useRef<Size?>(null);
+    final scheduledGestureController = useRef<VerticalReaderGestureController?>(
+      null,
+    );
+
+    void scheduleViewportConfiguration(Size viewportSize) {
+      if (viewportSize.isEmpty ||
+          !viewportSize.width.isFinite ||
+          !viewportSize.height.isFinite ||
+          (scheduledViewportSize.value == viewportSize &&
+              scheduledGestureController.value == gestureController)) {
+        return;
+      }
+
+      scheduledViewportSize.value = viewportSize;
+      scheduledGestureController.value = gestureController;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+
+        gestureController.configureViewport(viewportSize);
+      });
+    }
+
+    void setVisualScrollOffset(double visualScrollOffset) {
+      if (!scrollController.hasClients) return;
+
+      final position = scrollController.position;
+      final scaledMinScrollExtent =
+          position.minScrollExtent * gestureController.scale;
+      final scaledMaxScrollExtent =
+          position.maxScrollExtent * gestureController.scale;
+      final nextVisualScrollOffset = visualScrollOffset
+          .clamp(
+            scaledMinScrollExtent,
+            scaledMaxScrollExtent,
+          )
+          .toDouble();
+      final nextScrollOffset =
+          nextVisualScrollOffset
+              .clamp(scaledMinScrollExtent, scaledMaxScrollExtent)
+              .toDouble() /
+          gestureController.scale;
+
+      if (nextScrollOffset != position.pixels) {
+        position.jumpTo(nextScrollOffset);
+        scrolledDuringGesture.value = true;
+      }
+    }
+
+    void handleScaleStart(ScaleStartDetails details) {
+      gestureActive.value = true;
+      gestureIncludedPinch.value = details.pointerCount >= 2;
+      scrolledDuringGesture.value = false;
+      lastPointerCount.value = details.pointerCount;
+      lastScale.value = 1.0;
+      lastFocalPoint.value = details.localFocalPoint;
+
+      if (scrollController.hasClients) {
+        final position = scrollController.position;
+        position.jumpTo(position.pixels);
+      }
+    }
+
+    void scrollByVisualDelta(double visualDelta) {
+      if (visualDelta == 0.0 || !scrollController.hasClients) return;
+
+      final position = scrollController.position;
+      setVisualScrollOffset(
+        gestureController.visualScrollOffset(position.pixels) - visualDelta,
+      );
+    }
+
+    void handleScaleUpdate(ScaleUpdateDetails details) {
+      if (!gestureActive.value) return;
+
+      final focalPoint = details.localFocalPoint;
+      final focalPointDelta = focalPoint - lastFocalPoint.value;
+
+      if (details.pointerCount >= 2) {
+        gestureIncludedPinch.value = true;
+        if (lastPointerCount.value == details.pointerCount &&
+            scrollController.hasClients) {
+          final position = scrollController.position;
+          final nextVisualScrollOffset = gestureController.zoomViewport(
+            scaleFactor: details.scale / lastScale.value,
+            focalPoint: focalPoint,
+            focalPointDelta: focalPointDelta,
+            visualScrollOffset: gestureController.visualScrollOffset(
+              position.pixels,
+            ),
+          );
+          setVisualScrollOffset(nextVisualScrollOffset);
+        }
+
+        lastScale.value = details.scale;
+        lastFocalPoint.value = focalPoint;
+        lastPointerCount.value = details.pointerCount;
+        return;
+      }
+
+      lastScale.value = details.scale;
+      lastFocalPoint.value = focalPoint;
+      lastPointerCount.value = details.pointerCount;
+
+      if (gestureIncludedPinch.value) return;
+
+      gestureController.panHorizontally(focalPointDelta.dx);
+      scrollByVisualDelta(focalPointDelta.dy);
+    }
+
+    Future<void> handleScaleEnd(ScaleEndDetails details) async {
+      if (!gestureActive.value) return;
+
+      gestureActive.value = false;
+      if (gestureIncludedPinch.value ||
+          !scrolledDuringGesture.value ||
+          !scrollController.hasClients) {
+        return;
+      }
+
+      final position = scrollController.position;
+      if (position is ScrollPositionWithSingleContext) {
+        position.goBallistic(
+          -details.velocity.pixelsPerSecond.dy / gestureController.scale,
+        );
+      }
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        scheduleViewportConfiguration(constraints.biggest);
+
+        return GestureDetector(
+          behavior: .opaque,
+          onScaleStart: handleScaleStart,
+          onScaleUpdate: handleScaleUpdate,
+          onScaleEnd: (details) => unawaited(handleScaleEnd(details)),
+          child: ClipRect(
+            child: AnimatedBuilder(
+              animation: gestureController,
+              child: IgnorePointer(child: child),
+              builder: (context, child) {
+                return Transform.translate(
+                  offset: gestureController.translation,
+                  child: Transform.scale(
+                    scale: gestureController.scale,
+                    child: child,
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/test/pages/reader/image_reader/vertical_reader_gesture_controller_test.dart
+++ b/test/pages/reader/image_reader/vertical_reader_gesture_controller_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kover/pages/reader/image_reader/vertical_reader_gesture_controller.dart';
+
+void main() {
+  group('VerticalReaderGestureController', () {
+    test('horizontal pan stops at the scaled viewport edge', () {
+      final controller = _createController();
+
+      controller.zoomViewport(
+        scaleFactor: 2,
+        focalPoint: const Offset(150, 150),
+        focalPointDelta: Offset.zero,
+        visualScrollOffset: 0,
+      );
+      controller.panHorizontally(200);
+
+      expect(controller.translation, const Offset(150, 0));
+    });
+
+    test('zoom preserves horizontal focal point', () {
+      final controller = _createController();
+
+      controller.zoomViewport(
+        scaleFactor: 2,
+        focalPoint: const Offset(225, 150),
+        focalPointDelta: Offset.zero,
+        visualScrollOffset: 0,
+      );
+
+      expect(controller.scale, 2);
+      expect(controller.translation, const Offset(-75, 0));
+    });
+
+    test(
+      'zoom returns visual scroll offset preserving vertical focal point',
+      () {
+        final controller = _createController();
+
+        final visualScrollOffset = controller.zoomViewport(
+          scaleFactor: 2,
+          focalPoint: const Offset(150, 225),
+          focalPointDelta: Offset.zero,
+          visualScrollOffset: 100,
+        );
+
+        expect(visualScrollOffset, 275);
+      },
+    );
+
+    test('scaled viewport overflow is exposed as scroll padding', () {
+      final controller = _createController();
+
+      controller.zoomViewport(
+        scaleFactor: 2,
+        focalPoint: const Offset(150, 150),
+        focalPointDelta: Offset.zero,
+        visualScrollOffset: 0,
+      );
+
+      expect(controller.verticalScrollPadding, 75);
+      expect(controller.translation.dy, 0);
+    });
+  });
+}
+
+VerticalReaderGestureController _createController() {
+  return VerticalReaderGestureController()
+    ..configureViewport(const Size(300, 300));
+}

--- a/test/pages/reader/image_reader/zoomable_vertical_scroll_view_test.dart
+++ b/test/pages/reader/image_reader/zoomable_vertical_scroll_view_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kover/pages/reader/image_reader/vertical_reader_gesture_controller.dart';
+import 'package:kover/pages/reader/image_reader/zoomable_vertical_scroll_view.dart';
+
+void main() {
+  testWidgets('base-scale vertical drag scrolls the continuous list', (
+    tester,
+  ) async {
+    final scrollController = ScrollController();
+    final gestureController = VerticalReaderGestureController();
+    addTearDown(scrollController.dispose);
+    addTearDown(gestureController.dispose);
+    await tester.pumpWidget(
+      _buildScrollView(
+        scrollController: scrollController,
+        gestureController: gestureController,
+      ),
+    );
+    await tester.pump();
+
+    await tester.timedDrag(
+      find.byType(ZoomableVerticalScrollView),
+      const Offset(0, -100),
+      const Duration(seconds: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0));
+    expect(gestureController.translation, Offset.zero);
+  });
+
+  testWidgets('zoomed single-finger vertical drag scrolls the list', (
+    tester,
+  ) async {
+    final scrollController = ScrollController();
+    final gestureController = VerticalReaderGestureController();
+    addTearDown(scrollController.dispose);
+    addTearDown(gestureController.dispose);
+    await tester.pumpWidget(
+      _buildScrollView(
+        scrollController: scrollController,
+        gestureController: gestureController,
+      ),
+    );
+    await tester.pump();
+    gestureController.zoomViewport(
+      scaleFactor: 2,
+      focalPoint: const Offset(150, 150),
+      focalPointDelta: Offset.zero,
+      visualScrollOffset: 0,
+    );
+
+    await tester.timedDrag(
+      find.byType(ZoomableVerticalScrollView),
+      const Offset(0, -100),
+      const Duration(seconds: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0));
+    expect(gestureController.translation, Offset.zero);
+  });
+
+  testWidgets('zoomed horizontal drag pans without scrolling the list', (
+    tester,
+  ) async {
+    final scrollController = ScrollController();
+    final gestureController = VerticalReaderGestureController();
+    addTearDown(scrollController.dispose);
+    addTearDown(gestureController.dispose);
+    await tester.pumpWidget(
+      _buildScrollView(
+        scrollController: scrollController,
+        gestureController: gestureController,
+      ),
+    );
+    await tester.pump();
+    gestureController.zoomViewport(
+      scaleFactor: 2,
+      focalPoint: const Offset(150, 150),
+      focalPointDelta: Offset.zero,
+      visualScrollOffset: 0,
+    );
+
+    await tester.timedDrag(
+      find.byType(ZoomableVerticalScrollView),
+      const Offset(100, 0),
+      const Duration(seconds: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, 0);
+    expect(gestureController.translation, const Offset(100, 0));
+  });
+
+  testWidgets('zoomed top-edge vertical drag does not pan the viewport', (
+    tester,
+  ) async {
+    final scrollController = ScrollController();
+    final gestureController = VerticalReaderGestureController();
+    addTearDown(scrollController.dispose);
+    addTearDown(gestureController.dispose);
+    await tester.pumpWidget(
+      _buildScrollView(
+        scrollController: scrollController,
+        gestureController: gestureController,
+      ),
+    );
+    await tester.pump();
+    gestureController.zoomViewport(
+      scaleFactor: 2,
+      focalPoint: const Offset(150, 150),
+      focalPointDelta: Offset.zero,
+      visualScrollOffset: 0,
+    );
+
+    await tester.timedDrag(
+      find.byType(ZoomableVerticalScrollView),
+      const Offset(0, 100),
+      const Duration(seconds: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, 0);
+    expect(gestureController.translation, Offset.zero);
+  });
+
+  testWidgets('pinch sequence cannot scroll after one pointer lifts', (
+    tester,
+  ) async {
+    final scrollController = ScrollController();
+    final gestureController = VerticalReaderGestureController();
+    addTearDown(scrollController.dispose);
+    addTearDown(gestureController.dispose);
+    await tester.pumpWidget(
+      _buildScrollView(
+        scrollController: scrollController,
+        gestureController: gestureController,
+      ),
+    );
+    await tester.pump();
+    final firstPointer = await tester.startGesture(const Offset(100, 150));
+    final secondPointer = await tester.startGesture(const Offset(200, 150));
+
+    await firstPointer.moveTo(const Offset(50, 150));
+    await secondPointer.moveTo(const Offset(250, 150));
+    await tester.pump();
+    await secondPointer.up();
+    await firstPointer.moveBy(const Offset(0, -200));
+    await tester.pump();
+    await firstPointer.up();
+    await tester.pumpAndSettle();
+
+    expect(gestureController.scale, greaterThan(1));
+    expect(scrollController.offset, 0);
+  });
+}
+
+Widget _buildScrollView({
+  required ScrollController scrollController,
+  required VerticalReaderGestureController gestureController,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 300,
+          height: 300,
+          child: ZoomableVerticalScrollView(
+            scrollController: scrollController,
+            gestureController: gestureController,
+            child: ListView(
+              controller: scrollController,
+              children: List.generate(
+                10,
+                (index) => const SizedBox(height: 100),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Enhancement to #137

## Implementation overview:

- `ZoomableVerticalScrollView` wraps the existing vertical scroll view and applies zoom/pan transforms to the reader content.
- `VerticalReaderGestureController` tracks scale, viewport size, and horizontal translation.
- Pinch gestures zoom around the focal point while preserving the visual scroll position under the fingers.
- Single-finger vertical drags keep scrolling the list; horizontal drags pan the zoomed content.
- Extra vertical padding is added while zoomed so the scaled top/bottom content remains reachable.
- Pinch gestures cannot turn into scroll gestures after one finger is lifted.
- Tests cover focal-point zoom, pan clamping, scroll preservation, zoom padding, normal scrolling, horizontal panning, and pinch-vs-scroll behavior.

## AI assistance disclosure
I used Codex to help inspect the codebase and draft/iterate on parts of this implementation. I reviewed the generated changes and am responsible for follow-up fixes.