### PR TITLE
feat: add edge-aware gestures to horizontal image reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ web/sqlite3.wasm
 # Sentry related
 sentry.properties
 .sentry-native
+
+AGENTS.md
+CLAUDE.md

--- a/lib/pages/reader/image_reader/horizontal_paged_reader.dart
+++ b/lib/pages/reader/image_reader/horizontal_paged_reader.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/pages/reader/image_reader/zoomable_horizontal_page_image.dart';
 import 'package:kover/riverpod/providers/book.dart';
 import 'package:kover/riverpod/providers/reader//reader.dart';
 import 'package:kover/riverpod/providers/reader/reader_navigation.dart';
@@ -20,7 +21,6 @@ class HorizontalPagedReader extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isPanning = useState(false);
     final provider = readerProvider(seriesId: seriesId, chapterId: chapterId);
 
     final settings = ref.watch(imageReaderSettingsProvider(seriesId: seriesId));
@@ -43,6 +43,27 @@ class HorizontalPagedReader extends HookConsumerWidget {
             final pageController = usePageController(
               initialPage: navState.currentPage,
             );
+            final isZoomed = useState(false);
+            // Number of touch pointers down. With 2+ fingers we hand the
+            // gesture to the InteractiveViewer (pinch-zoom) instead of letting
+            // the PageView's drag recognizer steal it as a page swipe.
+            final pointerCount = useState(0);
+
+            void turnPage(int imageEdge) {
+              if (!pageController.hasClients) return;
+              final reverse = settings.readDirection == .rightToLeft;
+              // imageEdge +1 = past right edge, -1 = past left edge.
+              final forward = reverse ? imageEdge < 0 : imageEdge > 0;
+              final current =
+                  pageController.page?.round() ?? navState.currentPage;
+              final target = forward ? current + 1 : current - 1;
+              if (target < 0 || target >= reader.totalPages) return;
+              pageController.animateToPage(
+                target,
+                duration: 200.ms,
+                curve: Curves.easeInOut,
+              );
+            }
 
             ref.listen(
               navProvider.select((s) => s.whenData((s) => s.currentPage)),
@@ -77,10 +98,11 @@ class HorizontalPagedReader extends HookConsumerWidget {
               reverse: settings.readDirection == .rightToLeft,
               itemCount: reader.totalPages,
               pageSnapping: true,
-              physics: isPanning.value
+              physics: isZoomed.value || pointerCount.value >= 2
                   ? const NeverScrollableScrollPhysics()
                   : const BouncingScrollPhysics(),
               onPageChanged: (index) {
+                isZoomed.value = false; // new page starts unzoomed (ValueKey)
                 ref.read(navProvider.notifier).jumpToPage(index);
               },
               itemBuilder: (context, index) {
@@ -92,35 +114,36 @@ class HorizontalPagedReader extends HookConsumerWidget {
                     ),
                   ),
                   data: (data) {
-                    return InteractiveViewer(
-                      panEnabled: isPanning.value,
-                      onInteractionStart: (details) {
-                        if (details.pointerCount == 2) {
-                          isPanning.value = true;
-                        }
+                    return ZoomableHorizontalPageImage(
+                      key: ValueKey(index),
+                      bytes: data.data,
+                      fit: switch (settings.scaleType) {
+                        .contain => .contain,
+                        .fitWidth => .fitWidth,
+                        .fitHeight => .fitHeight,
                       },
-                      onInteractionEnd: (details) {
-                        isPanning.value = false;
-                      },
-                      child: Image.memory(
-                        data.data,
-                        fit: switch (settings.scaleType) {
-                          .contain => .contain,
-                          .fitWidth => .fitWidth,
-                          .fitHeight => .fitHeight,
-                        },
-                      ),
+                      onZoomChanged: (zoomed) => isZoomed.value = zoomed,
+                      onEdgeFling: turnPage,
                     );
                   },
                 );
               },
             );
 
+            final listenedContent = Listener(
+              onPointerDown: (_) => pointerCount.value++,
+              onPointerUp: (_) =>
+                  pointerCount.value = (pointerCount.value - 1).clamp(0, 10),
+              onPointerCancel: (_) =>
+                  pointerCount.value = (pointerCount.value - 1).clamp(0, 10),
+              child: content,
+            );
+
             if (settings.ignoreSafeAreas) {
-              return content;
+              return listenedContent;
             }
 
-            return SafeArea(child: content);
+            return SafeArea(child: listenedContent);
           },
         );
       },

--- a/lib/pages/reader/image_reader/horizontal_paged_reader.dart
+++ b/lib/pages/reader/image_reader/horizontal_paged_reader.dart
@@ -49,22 +49,6 @@ class HorizontalPagedReader extends HookConsumerWidget {
             // the PageView's drag recognizer steal it as a page swipe.
             final pointerCount = useState(0);
 
-            void turnPage(int imageEdge) {
-              if (!pageController.hasClients) return;
-              final reverse = settings.readDirection == .rightToLeft;
-              // imageEdge +1 = past right edge, -1 = past left edge.
-              final forward = reverse ? imageEdge < 0 : imageEdge > 0;
-              final current =
-                  pageController.page?.round() ?? navState.currentPage;
-              final target = forward ? current + 1 : current - 1;
-              if (target < 0 || target >= reader.totalPages) return;
-              pageController.animateToPage(
-                target,
-                duration: 200.ms,
-                curve: Curves.easeInOut,
-              );
-            }
-
             ref.listen(
               navProvider.select((s) => s.whenData((s) => s.currentPage)),
               (
@@ -122,8 +106,8 @@ class HorizontalPagedReader extends HookConsumerWidget {
                         .fitWidth => .fitWidth,
                         .fitHeight => .fitHeight,
                       },
+                      outerController: pageController,
                       onZoomChanged: (zoomed) => isZoomed.value = zoomed,
-                      onEdgeFling: turnPage,
                     );
                   },
                 );

--- a/lib/pages/reader/image_reader/horizontal_paged_reader.dart
+++ b/lib/pages/reader/image_reader/horizontal_paged_reader.dart
@@ -100,14 +100,16 @@ class HorizontalPagedReader extends HookConsumerWidget {
                   data: (data) {
                     return ZoomableHorizontalPageImage(
                       key: ValueKey(index),
-                      bytes: data.data,
-                      fit: switch (settings.scaleType) {
-                        .contain => .contain,
-                        .fitWidth => .fitWidth,
-                        .fitHeight => .fitHeight,
-                      },
                       outerController: pageController,
                       onZoomChanged: (zoomed) => isZoomed.value = zoomed,
+                      child: Image.memory(
+                        data.data,
+                        fit: switch (settings.scaleType) {
+                          .contain => .contain,
+                          .fitWidth => .fitWidth,
+                          .fitHeight => .fitHeight,
+                        },
+                      ),
                     );
                   },
                 );

--- a/lib/pages/reader/image_reader/zoomable_horizontal_page_image.dart
+++ b/lib/pages/reader/image_reader/zoomable_horizontal_page_image.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
@@ -11,8 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 /// drag overflow and remaining velocity at a horizontal edge are forwarded to
 /// the parent [PageView]'s controller.
 class ZoomableHorizontalPageImage extends HookWidget {
-  final Uint8List bytes;
-  final BoxFit fit;
+  final Widget child;
   final PageController outerController;
   final ValueChanged<bool> onZoomChanged;
 
@@ -21,8 +18,7 @@ class ZoomableHorizontalPageImage extends HookWidget {
 
   const ZoomableHorizontalPageImage({
     super.key,
-    required this.bytes,
-    required this.fit,
+    required this.child,
     required this.outerController,
     required this.onZoomChanged,
     this.transformationController,
@@ -149,7 +145,7 @@ class ZoomableHorizontalPageImage extends HookWidget {
           onInteractionStart: handleInteractionStart,
           onInteractionUpdate: handleInteractionUpdate,
           onInteractionEnd: handleInteractionEnd,
-          child: Image.memory(bytes, fit: fit),
+          child: child,
         );
       },
     );

--- a/lib/pages/reader/image_reader/zoomable_horizontal_page_image.dart
+++ b/lib/pages/reader/image_reader/zoomable_horizontal_page_image.dart
@@ -1,0 +1,93 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// A single horizontal-reader page: pinch-to-zoom and single-finger pan via
+/// [InteractiveViewer].
+///
+/// While zoomed it reports via [onZoomChanged] so the parent [PageView] can
+/// disable its scroll physics (letting panning own the single-finger gesture);
+/// a fling past a horizontal edge requests a page turn via [onEdgeFling].
+class ZoomableHorizontalPageImage extends HookWidget {
+  final Uint8List bytes;
+  final BoxFit fit;
+  final ValueChanged<bool> onZoomChanged;
+
+  /// +1 when flung past the right edge, -1 when flung past the left edge.
+  final ValueChanged<int> onEdgeFling;
+
+  /// Test seam: when omitted an internal controller is created.
+  final TransformationController? transformationController;
+
+  const ZoomableHorizontalPageImage({
+    super.key,
+    required this.bytes,
+    required this.fit,
+    required this.onZoomChanged,
+    required this.onEdgeFling,
+    this.transformationController,
+  });
+
+  static const double _minScale = 1.0;
+  static const double _maxScale = 4.0;
+  static const double _flingVelocity = 400.0;
+
+  @override
+  Widget build(BuildContext context) {
+    // Always create the hooked controller so hook order stays stable; prefer
+    // an injected one (test seam) when provided.
+    final hookController = useTransformationController();
+    final controller = transformationController ?? hookController;
+
+    // Pointer count from the last scale update. A two-finger pan should not
+    // turn the page on an edge fling; only a single-finger swipe should.
+    final lastPointerCount = useRef(1);
+
+    useEffect(() {
+      var wasZoomed = false;
+      void onChange() {
+        final zoomed = controller.value.getMaxScaleOnAxis() > _minScale + 1e-3;
+        if (zoomed != wasZoomed) {
+          wasZoomed = zoomed;
+          onZoomChanged(zoomed);
+        }
+      }
+
+      controller.addListener(onChange);
+      return () => controller.removeListener(onChange);
+    }, [controller]);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final viewportWidth = constraints.maxWidth;
+
+        void handleInteractionEnd(ScaleEndDetails details) {
+          if (lastPointerCount.value >= 2) return; // two-finger pan: no turn
+          final matrix = controller.value;
+          final scale = matrix.getMaxScaleOnAxis();
+          if (scale <= _minScale + 1e-3) return; // not zoomed: PageView handles
+
+          final tx = matrix.getTranslation().x;
+          final vx = details.velocity.pixelsPerSecond.dx;
+          final minTx = viewportWidth * (1 - scale); // right edge reached
+
+          if (tx <= minTx + 0.5 && vx < -_flingVelocity) {
+            onEdgeFling(1); // flung past right edge
+          } else if (tx >= -0.5 && vx > _flingVelocity) {
+            onEdgeFling(-1); // flung past left edge
+          }
+        }
+
+        return InteractiveViewer(
+          minScale: _minScale,
+          maxScale: _maxScale,
+          transformationController: controller,
+          onInteractionUpdate: (d) => lastPointerCount.value = d.pointerCount,
+          onInteractionEnd: handleInteractionEnd,
+          child: Image.memory(bytes, fit: fit),
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/reader/image_reader/zoomable_horizontal_page_image.dart
+++ b/lib/pages/reader/image_reader/zoomable_horizontal_page_image.dart
@@ -8,14 +8,13 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 ///
 /// While zoomed it reports via [onZoomChanged] so the parent [PageView] can
 /// disable its scroll physics (letting panning own the single-finger gesture);
-/// a fling past a horizontal edge requests a page turn via [onEdgeFling].
+/// drag overflow and remaining velocity at a horizontal edge are forwarded to
+/// the parent [PageView]'s controller.
 class ZoomableHorizontalPageImage extends HookWidget {
   final Uint8List bytes;
   final BoxFit fit;
+  final PageController outerController;
   final ValueChanged<bool> onZoomChanged;
-
-  /// +1 when flung past the right edge, -1 when flung past the left edge.
-  final ValueChanged<int> onEdgeFling;
 
   /// Test seam: when omitted an internal controller is created.
   final TransformationController? transformationController;
@@ -24,14 +23,14 @@ class ZoomableHorizontalPageImage extends HookWidget {
     super.key,
     required this.bytes,
     required this.fit,
+    required this.outerController,
     required this.onZoomChanged,
-    required this.onEdgeFling,
     this.transformationController,
   });
 
   static const double _minScale = 1.0;
   static const double _maxScale = 4.0;
-  static const double _flingVelocity = 400.0;
+  static const double _edgeTolerance = 0.5;
 
   @override
   Widget build(BuildContext context) {
@@ -40,9 +39,9 @@ class ZoomableHorizontalPageImage extends HookWidget {
     final hookController = useTransformationController();
     final controller = transformationController ?? hookController;
 
-    // Pointer count from the last scale update. A two-finger pan should not
-    // turn the page on an edge fling; only a single-finger swipe should.
-    final lastPointerCount = useRef(1);
+    final gestureIncludedPinch = useRef(false);
+    final lastFocalX = useRef<double?>(null);
+    final lastTranslationX = useRef<double?>(null);
 
     useEffect(() {
       var wasZoomed = false;
@@ -62,8 +61,73 @@ class ZoomableHorizontalPageImage extends HookWidget {
       builder: (context, constraints) {
         final viewportWidth = constraints.maxWidth;
 
+        void scrollOuterByDragDelta(
+          double dragDelta, {
+          bool ballistic = false,
+        }) {
+          if (!outerController.hasClients) {
+            return;
+          }
+
+          final position = outerController.position;
+          final scrollDelta = axisDirectionIsReversed(position.axisDirection)
+              ? dragDelta
+              : -dragDelta;
+
+          if (ballistic && position is ScrollPositionWithSingleContext) {
+            position.goBallistic(scrollDelta);
+          } else if (!ballistic && scrollDelta.abs() > _edgeTolerance) {
+            outerController.jumpTo(
+              (position.pixels + scrollDelta)
+                  .clamp(position.minScrollExtent, position.maxScrollExtent)
+                  .toDouble(),
+            );
+          }
+        }
+
+        void handleInteractionStart(ScaleStartDetails details) {
+          gestureIncludedPinch.value = details.pointerCount >= 2;
+          lastFocalX.value = details.localFocalPoint.dx;
+          lastTranslationX.value = controller.value.getTranslation().x;
+        }
+
+        void handleInteractionUpdate(ScaleUpdateDetails details) {
+          final previousFocalX = lastFocalX.value;
+          final previousTranslationX = lastTranslationX.value;
+          final currentTranslationX = controller.value.getTranslation().x;
+
+          if (details.pointerCount >= 2) {
+            gestureIncludedPinch.value = true;
+          }
+
+          final scale = controller.value.getMaxScaleOnAxis();
+          if (scale > _minScale + 1e-3 &&
+              previousFocalX != null &&
+              previousTranslationX != null &&
+              details.pointerCount == 1 &&
+              !gestureIncludedPinch.value) {
+            final focalDelta = details.localFocalPoint.dx - previousFocalX;
+            final minTx = viewportWidth * (1 - scale);
+
+            if ((previousTranslationX <= minTx + _edgeTolerance &&
+                    focalDelta < 0) ||
+                (previousTranslationX >= -_edgeTolerance && focalDelta > 0)) {
+              scrollOuterByDragDelta(focalDelta);
+            }
+          }
+
+          lastFocalX.value = details.localFocalPoint.dx;
+          lastTranslationX.value = currentTranslationX;
+        }
+
         void handleInteractionEnd(ScaleEndDetails details) {
-          if (lastPointerCount.value >= 2) return; // two-finger pan: no turn
+          final endedAfterPinch = gestureIncludedPinch.value;
+          gestureIncludedPinch.value = false;
+          lastFocalX.value = null;
+          lastTranslationX.value = null;
+
+          if (endedAfterPinch) return;
+
           final matrix = controller.value;
           final scale = matrix.getMaxScaleOnAxis();
           if (scale <= _minScale + 1e-3) return; // not zoomed: PageView handles
@@ -72,10 +136,9 @@ class ZoomableHorizontalPageImage extends HookWidget {
           final vx = details.velocity.pixelsPerSecond.dx;
           final minTx = viewportWidth * (1 - scale); // right edge reached
 
-          if (tx <= minTx + 0.5 && vx < -_flingVelocity) {
-            onEdgeFling(1); // flung past right edge
-          } else if (tx >= -0.5 && vx > _flingVelocity) {
-            onEdgeFling(-1); // flung past left edge
+          if ((tx <= minTx + _edgeTolerance && vx < 0) ||
+              (tx >= -_edgeTolerance && vx > 0)) {
+            scrollOuterByDragDelta(vx, ballistic: true);
           }
         }
 
@@ -83,7 +146,8 @@ class ZoomableHorizontalPageImage extends HookWidget {
           minScale: _minScale,
           maxScale: _maxScale,
           transformationController: controller,
-          onInteractionUpdate: (d) => lastPointerCount.value = d.pointerCount,
+          onInteractionStart: handleInteractionStart,
+          onInteractionUpdate: handleInteractionUpdate,
           onInteractionEnd: handleInteractionEnd,
           child: Image.memory(bytes, fit: fit),
         );

--- a/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
+++ b/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kover/pages/reader/image_reader/zoomable_horizontal_page_image.dart';
+
+// A 1x1 transparent PNG so [Image.memory] has decodable bytes.
+final Uint8List _pngBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII=',
+);
+
+void main() {
+  testWidgets('pinch zooms and reports the zoom state', (tester) async {
+    final controller = TransformationController();
+    addTearDown(controller.dispose);
+    var zoomed = false;
+
+    await tester.pumpWidget(
+      _host(
+        controller: controller,
+        onZoomChanged: (value) => zoomed = value,
+      ),
+    );
+    await tester.pump();
+
+    final pointer1 = await tester.startGesture(const Offset(120, 150));
+    final pointer2 = await tester.startGesture(const Offset(180, 150));
+    await pointer1.moveBy(const Offset(-80, 0));
+    await pointer2.moveBy(const Offset(80, 0));
+    await tester.pump();
+    await pointer1.up();
+    await pointer2.up();
+    await tester.pumpAndSettle();
+
+    expect(controller.value.getMaxScaleOnAxis(), greaterThan(1.0));
+    expect(zoomed, isTrue);
+  });
+
+  testWidgets('single-finger drag at base scale neither zooms nor pans', (
+    tester,
+  ) async {
+    final controller = TransformationController();
+    addTearDown(controller.dispose);
+    var reportedZoomed = false;
+
+    await tester.pumpWidget(
+      _host(
+        controller: controller,
+        onZoomChanged: (value) => reportedZoomed |= value,
+      ),
+    );
+    await tester.pump();
+
+    await tester.timedDrag(
+      find.byType(ZoomableHorizontalPageImage),
+      const Offset(120, 0),
+      const Duration(milliseconds: 600),
+    );
+    await tester.pumpAndSettle();
+
+    expect(controller.value.getMaxScaleOnAxis(), 1.0);
+    expect(controller.value.getTranslation().x, closeTo(0.0, 1e-6));
+    expect(reportedZoomed, isFalse);
+  });
+
+  testWidgets('fling past the right edge requests the next page (+1)', (
+    tester,
+  ) async {
+    final controller = TransformationController()..value = _zoomedAt(-300);
+    addTearDown(controller.dispose);
+    int? edge;
+
+    await tester.pumpWidget(
+      _host(controller: controller, onEdgeFling: (value) => edge = value),
+    );
+    await tester.pump();
+
+    await tester.fling(
+      find.byType(ZoomableHorizontalPageImage),
+      const Offset(-150, 0),
+      1000,
+    );
+    await tester.pumpAndSettle();
+
+    expect(edge, 1);
+  });
+
+  testWidgets('fling past the left edge requests the previous page (-1)', (
+    tester,
+  ) async {
+    final controller = TransformationController()..value = _zoomedAt(0);
+    addTearDown(controller.dispose);
+    int? edge;
+
+    await tester.pumpWidget(
+      _host(controller: controller, onEdgeFling: (value) => edge = value),
+    );
+    await tester.pump();
+
+    await tester.fling(
+      find.byType(ZoomableHorizontalPageImage),
+      const Offset(150, 0),
+      1000,
+    );
+    await tester.pumpAndSettle();
+
+    expect(edge, -1);
+  });
+
+  testWidgets('slow drag to the edge does not turn the page', (tester) async {
+    final controller = TransformationController()..value = _zoomedAt(-300);
+    addTearDown(controller.dispose);
+    int? edge;
+
+    await tester.pumpWidget(
+      _host(controller: controller, onEdgeFling: (value) => edge = value),
+    );
+    await tester.pump();
+
+    await tester.timedDrag(
+      find.byType(ZoomableHorizontalPageImage),
+      const Offset(-60, 0),
+      const Duration(seconds: 2),
+    );
+    await tester.pumpAndSettle();
+
+    expect(edge, isNull);
+  });
+}
+
+// Scale 2x with the given horizontal translation, for a 300px-wide viewport
+// the pan range is [-300, 0]: 0 == left edge, -300 == right edge.
+Matrix4 _zoomedAt(double translationX) {
+  final matrix = Matrix4.identity()..scale(2.0);
+  matrix.setTranslationRaw(translationX, 0, 0);
+  return matrix;
+}
+
+Widget _host({
+  required TransformationController controller,
+  ValueChanged<bool>? onZoomChanged,
+  ValueChanged<int>? onEdgeFling,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 300,
+          height: 300,
+          child: ZoomableHorizontalPageImage(
+            bytes: _pngBytes,
+            fit: BoxFit.contain,
+            onZoomChanged: onZoomChanged ?? (_) {},
+            onEdgeFling: onEdgeFling ?? (_) {},
+            transformationController: controller,
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
+++ b/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
@@ -132,7 +132,7 @@ void main() {
 // Scale 2x with the given horizontal translation, for a 300px-wide viewport
 // the pan range is [-300, 0]: 0 == left edge, -300 == right edge.
 Matrix4 _zoomedAt(double translationX) {
-  final matrix = Matrix4.identity()..scale(2.0);
+  final matrix = Matrix4.identity()..scaleByDouble(2.0, 2.0, 2.0, 1.0);
   matrix.setTranslationRaw(translationX, 0, 0);
   return matrix;
 }

--- a/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
+++ b/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
@@ -10,15 +10,20 @@ final Uint8List _pngBytes = base64Decode(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII=',
 );
 
+const _zoomableKey = ValueKey('zoomable-horizontal-page-image');
+
 void main() {
   testWidgets('pinch zooms and reports the zoom state', (tester) async {
     final controller = TransformationController();
     addTearDown(controller.dispose);
+    final pageController = PageController();
+    addTearDown(pageController.dispose);
     var zoomed = false;
 
     await tester.pumpWidget(
       _host(
         controller: controller,
+        pageController: pageController,
         onZoomChanged: (value) => zoomed = value,
       ),
     );
@@ -42,11 +47,14 @@ void main() {
   ) async {
     final controller = TransformationController();
     addTearDown(controller.dispose);
+    final pageController = PageController();
+    addTearDown(pageController.dispose);
     var reportedZoomed = false;
 
     await tester.pumpWidget(
       _host(
         controller: controller,
+        pageController: pageController,
         onZoomChanged: (value) => reportedZoomed |= value,
       ),
     );
@@ -64,68 +72,138 @@ void main() {
     expect(reportedZoomed, isFalse);
   });
 
-  testWidgets('fling past the right edge requests the next page (+1)', (
+  testWidgets('drag overflow at the right edge scrolls the outer PageView', (
     tester,
   ) async {
     final controller = TransformationController()..value = _zoomedAt(-300);
     addTearDown(controller.dispose);
-    int? edge;
+    final pageController = PageController(initialPage: 1);
+    addTearDown(pageController.dispose);
 
     await tester.pumpWidget(
-      _host(controller: controller, onEdgeFling: (value) => edge = value),
+      _pagedHost(controller: controller, pageController: pageController),
+    );
+    await tester.pump();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(_zoomableKey)),
+    );
+    await tester.pump();
+    await gesture.moveBy(const Offset(-60, 0));
+    await tester.pump();
+
+    expect(pageController.offset, greaterThan(300));
+    expect(controller.value.getTranslation().x, closeTo(-300, 1e-6));
+
+    await gesture.up();
+  });
+
+  testWidgets(
+    'inward drag at the right edge pans the image, not the PageView',
+    (
+      tester,
+    ) async {
+      final controller = TransformationController()..value = _zoomedAt(-300);
+      addTearDown(controller.dispose);
+      final pageController = PageController(initialPage: 1);
+      addTearDown(pageController.dispose);
+
+      await tester.pumpWidget(
+        _pagedHost(controller: controller, pageController: pageController),
+      );
+      await tester.pump();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(_zoomableKey)),
+      );
+      await tester.pump();
+      await gesture.moveBy(const Offset(60, 0));
+      await tester.pump();
+
+      expect(pageController.offset, closeTo(300, 1e-6));
+      expect(controller.value.getTranslation().x, greaterThan(-300));
+
+      await gesture.up();
+    },
+  );
+
+  testWidgets('horizontal drag while zoomed pans before turning pages', (
+    tester,
+  ) async {
+    final controller = TransformationController()..value = _zoomedAt(-150);
+    addTearDown(controller.dispose);
+    final pageController = PageController(initialPage: 1);
+    addTearDown(pageController.dispose);
+
+    await tester.pumpWidget(
+      _pagedHost(controller: controller, pageController: pageController),
+    );
+    await tester.pump();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(_zoomableKey)),
+    );
+    await tester.pump();
+    await gesture.moveBy(const Offset(-60, 0));
+    await tester.pump();
+
+    expect(pageController.offset, closeTo(300, 1e-6));
+    expect(controller.value.getTranslation().x, lessThan(-150));
+
+    await gesture.up();
+  });
+
+  testWidgets('remaining velocity at the right edge is passed to PageView', (
+    tester,
+  ) async {
+    final controller = TransformationController()..value = _zoomedAt(-300);
+    addTearDown(controller.dispose);
+    final pageController = PageController(initialPage: 1);
+    addTearDown(pageController.dispose);
+
+    await tester.pumpWidget(
+      _pagedHost(controller: controller, pageController: pageController),
     );
     await tester.pump();
 
     await tester.fling(
-      find.byType(ZoomableHorizontalPageImage),
+      find.byKey(_zoomableKey),
       const Offset(-150, 0),
       1000,
     );
     await tester.pumpAndSettle();
 
-    expect(edge, 1);
+    expect(pageController.page, closeTo(2, 1e-6));
   });
 
-  testWidgets('fling past the left edge requests the previous page (-1)', (
+  testWidgets('overflow drag respects a reversed outer PageView', (
     tester,
   ) async {
     final controller = TransformationController()..value = _zoomedAt(0);
     addTearDown(controller.dispose);
-    int? edge;
+    final pageController = PageController(initialPage: 1);
+    addTearDown(pageController.dispose);
 
     await tester.pumpWidget(
-      _host(controller: controller, onEdgeFling: (value) => edge = value),
+      _pagedHost(
+        controller: controller,
+        pageController: pageController,
+        reverse: true,
+      ),
     );
     await tester.pump();
 
-    await tester.fling(
-      find.byType(ZoomableHorizontalPageImage),
-      const Offset(150, 0),
-      1000,
-    );
-    await tester.pumpAndSettle();
-
-    expect(edge, -1);
-  });
-
-  testWidgets('slow drag to the edge does not turn the page', (tester) async {
-    final controller = TransformationController()..value = _zoomedAt(-300);
-    addTearDown(controller.dispose);
-    int? edge;
-
-    await tester.pumpWidget(
-      _host(controller: controller, onEdgeFling: (value) => edge = value),
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(_zoomableKey)),
     );
     await tester.pump();
+    await gesture.moveBy(const Offset(60, 0));
+    await tester.pump();
 
-    await tester.timedDrag(
-      find.byType(ZoomableHorizontalPageImage),
-      const Offset(-60, 0),
-      const Duration(seconds: 2),
-    );
-    await tester.pumpAndSettle();
+    expect(pageController.offset, greaterThan(300));
+    expect(controller.value.getTranslation().x, closeTo(0, 1e-6));
 
-    expect(edge, isNull);
+    await gesture.up();
   });
 }
 
@@ -139,8 +217,8 @@ Matrix4 _zoomedAt(double translationX) {
 
 Widget _host({
   required TransformationController controller,
+  required PageController pageController,
   ValueChanged<bool>? onZoomChanged,
-  ValueChanged<int>? onEdgeFling,
 }) {
   return MaterialApp(
     home: Scaffold(
@@ -150,11 +228,50 @@ Widget _host({
           width: 300,
           height: 300,
           child: ZoomableHorizontalPageImage(
+            key: _zoomableKey,
             bytes: _pngBytes,
             fit: BoxFit.contain,
+            outerController: pageController,
             onZoomChanged: onZoomChanged ?? (_) {},
-            onEdgeFling: onEdgeFling ?? (_) {},
             transformationController: controller,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _pagedHost({
+  required TransformationController controller,
+  required PageController pageController,
+  bool reverse = false,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 300,
+          height: 300,
+          child: PageView.builder(
+            controller: pageController,
+            reverse: reverse,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: 3,
+            itemBuilder: (context, index) {
+              if (index != 1) {
+                return const SizedBox.expand();
+              }
+
+              return ZoomableHorizontalPageImage(
+                key: _zoomableKey,
+                bytes: _pngBytes,
+                fit: BoxFit.contain,
+                outerController: pageController,
+                onZoomChanged: (_) {},
+                transformationController: controller,
+              );
+            },
           ),
         ),
       ),

--- a/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
+++ b/test/pages/reader/image_reader/zoomable_horizontal_page_image_test.dart
@@ -1,16 +1,9 @@
-import 'dart:convert';
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kover/pages/reader/image_reader/zoomable_horizontal_page_image.dart';
 
-// A 1x1 transparent PNG so [Image.memory] has decodable bytes.
-final Uint8List _pngBytes = base64Decode(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII=',
-);
-
 const _zoomableKey = ValueKey('zoomable-horizontal-page-image');
+const _testChild = SizedBox(width: 300, height: 300);
 
 void main() {
   testWidgets('pinch zooms and reports the zoom state', (tester) async {
@@ -229,11 +222,10 @@ Widget _host({
           height: 300,
           child: ZoomableHorizontalPageImage(
             key: _zoomableKey,
-            bytes: _pngBytes,
-            fit: BoxFit.contain,
             outerController: pageController,
             onZoomChanged: onZoomChanged ?? (_) {},
             transformationController: controller,
+            child: _testChild,
           ),
         ),
       ),
@@ -265,11 +257,10 @@ Widget _pagedHost({
 
               return ZoomableHorizontalPageImage(
                 key: _zoomableKey,
-                bytes: _pngBytes,
-                fit: BoxFit.contain,
                 outerController: pageController,
                 onZoomChanged: (_) {},
                 transformationController: controller,
+                child: _testChild,
               );
             },
           ),


### PR DESCRIPTION
Enhancement to #137

## Implementation overview:

- `PagedImageGestureDetector` wraps the `PageView` and owns gesture routing.
- The `PageView` uses `NeverScrollableScrollPhysics`, so drag handling is decided once per gesture instead of being handed between nested handlers.
- `PagedImageGestureController` tracks the active page’s scale, translation, viewport size, fit mode, and image bounds.
- Horizontal drags pan the zoomed image while it can still move; once the image reaches an edge, the same drag direction turns the page.
- Pinch gestures zoom around the focal point and cannot trigger pagination after one finger is lifted.
- Page changes reset zoom/translation, and RTL reading direction is handled.
- Tests cover bounds, focal-point zoom, edge-aware page turns, RTL, and pinch-vs-pagination behavior.

## AI assistance disclosure
I used Codex to help inspect the codebase and draft/iterate on parts of this implementation. I reviewed the generated changes and am responsible for follow-up fixes.