### PR TITLE
fix: show orientation lock on mobile only

### DIFF
--- a/lib/pages/reader/epub_reader/epub_reader_controls.dart
+++ b/lib/pages/reader/epub_reader/epub_reader_controls.dart
@@ -4,6 +4,7 @@ import 'package:kover/generated/l10n/app_localizations.dart';
 import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
 import 'package:kover/riverpod/providers/settings/epub_reader_settings.dart';
 import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/utils/safe_platform.dart';
 import 'package:kover/widgets/settings/boolean_option.dart';
 import 'package:kover/widgets/settings/numeric_option.dart';
 import 'package:kover/widgets/settings/reader/orientation_option.dart';
@@ -104,7 +105,8 @@ class EpubReaderSettingsBottomSheet extends ConsumerWidget {
                             .read(epubSettings.notifier)
                             .setLetterSpacing(newValue),
                       ),
-                      OrientationOption(seriesId: seriesId),
+                      if (SafePlatform.isMobile)
+                        OrientationOption(seriesId: seriesId),
                       BooleanOption(
                         icon: LucideIcons.highlighter,
                         title: l.highlightResumeParagraph,

--- a/lib/pages/reader/pdf_reader/pdf_reader_controls.dart
+++ b/lib/pages/reader/pdf_reader/pdf_reader_controls.dart
@@ -5,6 +5,7 @@ import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
 import 'package:kover/riverpod/providers/settings/pdf_reader_settings.dart';
 import 'package:kover/utils/constants/kover_icons.dart';
 import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/utils/safe_platform.dart';
 import 'package:kover/widgets/settings/boolean_option.dart';
 import 'package:kover/widgets/settings/choice_option.dart';
 import 'package:kover/widgets/settings/reader/orientation_option.dart';
@@ -72,7 +73,8 @@ class PdfReaderSettingsBottomSheet extends ConsumerWidget {
                               .setReaderMode(newValue);
                         },
                       ),
-                      OrientationOption(seriesId: seriesId),
+                      if (SafePlatform.isMobile)
+                        OrientationOption(seriesId: seriesId),
                       BooleanOption(
                         title: l.ignoreSafeAreas,
                         icon: KoverIcons.safeArea,


### PR DESCRIPTION
missed for epub and pdf controls