### PR TITLE
fix: pin collapse mode for details app bar

### DIFF
--- a/lib/widgets/lists/adaptive_sliver_app_bar.dart
+++ b/lib/widgets/lists/adaptive_sliver_app_bar.dart
@@ -59,6 +59,7 @@ class AdaptiveSliverAppBar extends HookConsumerWidget {
           return Opacity(
             opacity: value.clamp(0.0, 1.0),
             child: FlexibleSpaceBar(
+              collapseMode: .pin,
               background: Stack(
                 children: [
                   if (background != null)


### PR DESCRIPTION
keeps the resume button pinned and clickable all the way to collapsed