### PR TITLE
chore: pool sync engine requests

### DIFF
--- a/lib/riverpod/managers/sync_manager.dart
+++ b/lib/riverpod/managers/sync_manager.dart
@@ -148,15 +148,15 @@ class SyncManager extends _$SyncManager {
 
     _enqueuePhases({const .allSeries()});
     _enqueuePhases({
+      const .progress(),
       const .libraries(),
-      const .metadata(),
-      const .tocs(),
       const .recentlyUpdated(),
       const .recentlyAdded(),
-      const .progress(),
-      const .refreshServerSettings(),
       const .collections(),
       const .readingLists(),
+      const .metadata(),
+      const .tocs(),
+      const .refreshServerSettings(),
       const .sidenav(),
       if (settings.downloadCovers) const .covers(),
     });

--- a/lib/riverpod/repository/series_repository.dart
+++ b/lib/riverpod/repository/series_repository.dart
@@ -230,8 +230,10 @@ class SeriesRepository {
                     r.lastSynced!.isBefore(companion.lastChapterAdded.value!));
             final hasNewProgress =
                 companion.remoteLastRead.value != null &&
-                (r.lastSynced == null ||
-                    r.lastSynced!.isBefore(companion.remoteLastRead.value!));
+                (r.remoteLastRead == null ||
+                    r.remoteLastRead!.isBefore(
+                      companion.remoteLastRead.value!,
+                    ));
 
             return neverSynced || hasNewChapter || hasNewProgress;
           },

--- a/lib/sync/sync_engine.dart
+++ b/lib/sync/sync_engine.dart
@@ -8,6 +8,7 @@ import 'package:kover/riverpod/repository/series_repository.dart';
 import 'package:kover/riverpod/repository/server_settings_repository.dart';
 import 'package:kover/riverpod/repository/volumes_repository.dart';
 import 'package:kover/riverpod/repository/want_to_read_repository.dart';
+import 'package:pool/pool.dart';
 
 class SyncEngine {
   final SeriesRepository seriesRepo;
@@ -21,7 +22,9 @@ class SyncEngine {
   final CollectionsRepository collectionsRepo;
   final ReadingListsRepository readingListsRepo;
 
-  const SyncEngine({
+  final _pool = Pool(4);
+
+  SyncEngine({
     required this.seriesRepo,
     required this.bookRepo,
     required this.librariesRepo,
@@ -35,71 +38,77 @@ class SyncEngine {
   });
 
   Future<void> syncAllSeries() async {
-    await seriesRepo.refreshAllSeries();
-    await seriesRepo.fetchMissingMetadata();
+    await _pool.withResource(seriesRepo.refreshAllSeries);
+    await _pool.withResource(seriesRepo.fetchMissingMetadata);
   }
 
   Future<void> syncMetadata() async {
-    await seriesRepo.fetchMissingMetadata();
+    await _pool.withResource(seriesRepo.fetchMissingMetadata);
   }
 
   Future<void> syncTocs() async {
-    await bookRepo.fetchMissingChaptersTocs();
+    await _pool.withResource(bookRepo.fetchMissingChaptersTocs);
   }
 
   Future<void> syncLibraries() async {
-    await librariesRepo.refreshLibraries();
-    await wantToReadRepo.mergeWantToRead();
+    await _pool.withResource(librariesRepo.refreshLibraries);
+    await _pool.withResource(wantToReadRepo.mergeWantToRead);
   }
 
   Future<void> syncRecentlyUpdated() async {
-    await seriesRepo.refreshRecentlyUpdated();
+    await _pool.withResource(seriesRepo.refreshRecentlyUpdated);
   }
 
   Future<void> syncRecentlyAdded() async {
-    await seriesRepo.refreshRecentlyAdded();
+    await _pool.withResource(seriesRepo.refreshRecentlyAdded);
   }
 
   Future<void> syncProgress() async {
-    await readerRepo.refreshOutdatedProgress();
-    await readerRepo.mergeProgress();
+    await _pool.withResource(readerRepo.refreshOutdatedProgress);
+    await _pool.withResource(readerRepo.mergeProgress);
   }
 
   Future<void> syncCollections() async {
-    await collectionsRepo.refreshCollections();
+    await _pool.withResource(collectionsRepo.refreshCollections);
   }
 
   Future<void> syncReadingLists() async {
-    await readingListsRepo.refreshReadingLists();
+    await _pool.withResource(readingListsRepo.refreshReadingLists);
   }
 
   Future<void> syncCovers() async {
     await Future.wait([
-      seriesRepo.fetchMissingCovers(),
-      volumesRepo.fetchMissingCovers(),
-      chaptersRepo.fetchMissingCovers(),
-      collectionsRepo.fetchMissingCovers(),
-      readingListsRepo.fetchMissingCovers(),
+      _pool.withResource(seriesRepo.fetchMissingCovers),
+      _pool.withResource(volumesRepo.fetchMissingCovers),
+      _pool.withResource(chaptersRepo.fetchMissingCovers),
+      _pool.withResource(collectionsRepo.fetchMissingCovers),
+      _pool.withResource(readingListsRepo.fetchMissingCovers),
     ]);
   }
 
   Future<void> syncSidenav() async {
-    await librariesRepo.refreshSidenav();
+    await _pool.withResource(librariesRepo.refreshSidenav);
   }
 
   Future<void> refreshMetadataAndDetails({required int seriesId}) async {
-    await seriesRepo.refreshMetadataAndDetails(seriesId: seriesId);
+    await _pool.withResource(
+      () => seriesRepo.refreshMetadataAndDetails(seriesId: seriesId),
+    );
   }
 
   Future<void> refreshCovers({required int seriesId}) async {
-    await seriesRepo.refreshCovers(seriesId: seriesId);
+    await _pool.withResource(
+      () => seriesRepo.refreshCovers(seriesId: seriesId),
+    );
   }
 
   Future<void> refreshToc({required int chapterId}) async {
-    await bookRepo.refreshChapterToc(chapterId: chapterId);
+    await _pool.withResource(
+      () => bookRepo.refreshChapterToc(chapterId: chapterId),
+    );
   }
 
   Future<void> refreshServerSettings() async {
-    await serverSettingsRepo.refreshServerSettings();
+    await _pool.withResource(serverSettingsRepo.refreshServerSettings);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1086,7 +1086,7 @@ packages:
     source: hosted
     version: "2.1.8"
   pool:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pool
       sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.20.0
+  pool: ^1.5.2
 
 dev_dependencies:
   sentry_dart_plugin: ^3.4.0

--- a/test/riverpod/repository/series_repository_test.dart
+++ b/test/riverpod/repository/series_repository_test.dart
@@ -191,6 +191,7 @@ void main() {
           format: const Value(.epub),
           created: Value(now),
           lastChapterAdded: Value(now),
+          lastSynced: Value(now),
           remoteLastRead: Value(now),
         ),
       ];
@@ -209,6 +210,7 @@ void main() {
           created: now,
           lastChapterAdded: now,
           lastSynced: now,
+          remoteLastRead: now,
         ),
       ];
 


### PR DESCRIPTION
avoid overloading by pooling async operations in sync engine