### PR TITLE
feat: add text-indent support

### DIFF
--- a/lib/utils/extensions/epub_page_preprocessor.dart
+++ b/lib/utils/extensions/epub_page_preprocessor.dart
@@ -1,6 +1,8 @@
 import 'package:csslib/parser.dart' as css;
 import 'package:csslib/visitor.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:html/dom.dart';
+import 'package:html/dom_parsing.dart';
 import 'package:kover/utils/extensions/element.dart';
 import 'package:kover/utils/html_constants.dart';
 import 'package:kover/utils/logging.dart';
@@ -22,6 +24,7 @@ extension EpubPagePreprocessor on DocumentFragment {
     final elementMap = _matchRulesToElements(root, rules);
     _applyInlinedStyles(elementMap);
     _applyScrollIds(root);
+    _applyTextIndent(root);
 
     return root;
   }
@@ -93,6 +96,31 @@ extension EpubPagePreprocessor on DocumentFragment {
     for (final child in root.children) {
       walk(child);
     }
+  }
+
+  static void _applyTextIndent(DocumentFragment root) {
+    final visitor = _TextIndentVisitor();
+    visitor.visit(root);
+  }
+}
+
+class _TextIndentVisitor extends TreeVisitor {
+  @override
+  void visitElement(Element element) {
+    final textIndent = element.styles
+        .where((s) => s.property == 'text-indent')
+        .firstOrNull;
+
+    if (textIndent != null && textIndent.value?.span?.text != null) {
+      final span = Element.tag('span')
+        ..text =
+            '\u00A0' // Non-breaking space
+        ..attributes['style'] =
+            'display: inline-block; width: ${textIndent.value!.span!.text}';
+      element.insertBefore(span, element.firstChild);
+    }
+
+    super.visitElement(element);
   }
 }
 

--- a/lib/utils/extensions/epub_page_preprocessor.dart
+++ b/lib/utils/extensions/epub_page_preprocessor.dart
@@ -105,22 +105,49 @@ extension EpubPagePreprocessor on DocumentFragment {
 }
 
 class _TextIndentVisitor extends TreeVisitor {
+  static const blockElements = {
+    'div',
+    'p',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'li',
+  };
+
+  String? _inheritedTextIndent;
+
   @override
   void visitElement(Element element) {
-    final textIndent = element.styles
+    final explicitTextIndent = element.styles
         .where((s) => s.property == 'text-indent')
-        .firstOrNull;
+        .firstOrNull
+        ?.value
+        ?.span
+        ?.text;
 
-    if (textIndent != null && textIndent.value?.span?.text != null) {
+    final currentTextIndent = explicitTextIndent ?? _inheritedTextIndent;
+
+    if (currentTextIndent != null &&
+        blockElements.contains(element.localName)) {
       final span = Element.tag('span')
         ..text =
             '\u00A0' // Non-breaking space
         ..attributes['style'] =
-            'display: inline-block; width: ${textIndent.value!.span!.text}';
+            'display: inline-block; width: $currentTextIndent';
+
       element.insertBefore(span, element.firstChild);
     }
 
+    final previousInherited = _inheritedTextIndent;
+
+    _inheritedTextIndent = currentTextIndent;
+
     super.visitElement(element);
+
+    _inheritedTextIndent = previousInherited;
   }
 }
 


### PR DESCRIPTION
flutter_widget_from_html does not natively support text-indent. Work around the limitation by injecting spans with width matching the indent size as the first child of elments that define a text-indent. This should be enough for most cases to render the epub pages as expected with respect to the paragraph indentation

closes #295 