### PR TITLE
fix: don't split indent spans during reflow

### DIFF
--- a/lib/utils/element_cursor.dart
+++ b/lib/utils/element_cursor.dart
@@ -1,4 +1,5 @@
 import 'package:html/dom.dart';
+import 'package:kover/utils/html_constants.dart';
 
 class ElementCursor {
   static const Set<String> _leafTags = {'img', 'svg'};
@@ -66,7 +67,8 @@ class ElementCursor {
 
     if (child is! Element ||
         _leafTags.contains(child.localName) ||
-        child.nodes.isEmpty) {
+        child.nodes.isEmpty ||
+        child.attributes.containsKey(HtmlConstants.textIndentSpanAttribute)) {
       return false;
     }
 

--- a/lib/utils/extensions/epub_page_preprocessor.dart
+++ b/lib/utils/extensions/epub_page_preprocessor.dart
@@ -133,10 +133,14 @@ class _TextIndentVisitor extends TreeVisitor {
     if (currentTextIndent != null &&
         blockElements.contains(element.localName)) {
       final span = Element.tag('span')
-        ..text =
-            '\u00A0' // Non-breaking space
+        ..text = ' '
+        ..attributes[HtmlConstants.textIndentSpanAttribute] = ''
         ..attributes['style'] =
             'display: inline-block; width: $currentTextIndent';
+
+      log.debug(
+        'Applying text-indent: $currentTextIndent to ${element.localName}',
+      );
 
       element.insertBefore(span, element.firstChild);
     }

--- a/lib/utils/html_constants.dart
+++ b/lib/utils/html_constants.dart
@@ -3,4 +3,5 @@ sealed class HtmlConstants {
   static const String resumeParagraphClass = 'resume-paragraph';
   static const String kavitaWrapperClass = 'book-content';
   static const String koverWrapperClass = 'kover-content';
+  static const String textIndentSpanAttribute = 'indent-span';
 }


### PR DESCRIPTION
Trying to split the empty spans leads to empty paragraphs that may cause scrolling to kick in and the resume highlight being on the empty space at the end of the page