### PR TITLE
fix: drop whitespace when splitting words

### DIFF
--- a/lib/utils/reflow_engine.dart
+++ b/lib/utils/reflow_engine.dart
@@ -141,6 +141,12 @@ class BinaryReflowEngine implements ReflowEngine {
     }
     frame.pending.removeRange(0, frame.lo);
 
+    // Drop whitespace at the start of the next page.
+    if (frame.pending.isNotEmpty && frame.pending.first is Text) {
+      final first = frame.pending.first as Text;
+      first.data = first.data.trimLeft();
+    }
+
     // Ancestors committed everything before the straddler unit. The unit
     // itself stays (hollow) so the child shell swap keeps its slot.
     for (final f in _frames.take(_frames.length - 1)) {

--- a/test/utils/reflow_engine_test.dart
+++ b/test/utils/reflow_engine_test.dart
@@ -148,7 +148,7 @@ void main() {
         final expectedCommit = Element.tag('div')
           ..append(Element.tag('p')..append(Text('Hello.')));
         final expectedNext = Element.tag('div')
-          ..append(Element.tag('p')..append(Text(' There. Sentences.')));
+          ..append(Element.tag('p')..append(Text('There. Sentences.')));
 
         final engine = BinaryReflowEngine(root: root);
 
@@ -181,7 +181,7 @@ void main() {
         final expectedCommit = Element.tag('div')
           ..append(Element.tag('p')..append(Text('Hello.')));
         final expectedNext = Element.tag('div')
-          ..append(Element.tag('p')..append(Text(' There. Sentences')));
+          ..append(Element.tag('p')..append(Text('There. Sentences')));
 
         final engine = BinaryReflowEngine(root: root);
 
@@ -212,7 +212,7 @@ void main() {
       final expectedCommit = Element.tag('div')
         ..append(Element.tag('p')..append(Text('"Hello."')));
       final expectedNext = Element.tag('div')
-        ..append(Element.tag('p')..append(Text(' "There."')));
+        ..append(Element.tag('p')..append(Text('"There."')));
 
       final engine = BinaryReflowEngine(root: root);
 
@@ -230,13 +230,13 @@ void main() {
       expect(engine.buffer.outerHtml, equals(expectedNext.outerHtml));
     });
 
-    test('when splitting words, whitespace stays on the following word', () {
+    test('when splitting words, split whitespace is dropped', () {
       // <p>Hello there white space</p>
       final root = Element.tag('p')..append(Text('Hello there white space'));
       // The page-ending word carries no trailing whitespace ...
       final expectedCommit = Element.tag('p')..append(Text('Hello there'));
       // ... it is kept on the following word: no whitespace is lost.
-      final expectedNext = Element.tag('p')..append(Text(' white space'));
+      final expectedNext = Element.tag('p')..append(Text('white space'));
 
       final engine = BinaryReflowEngine(root: root);
 
@@ -252,7 +252,6 @@ void main() {
       expect(commit.outerHtml, equals(expectedCommit.outerHtml));
       expect(res, isTrue);
       expect(engine.buffer.outerHtml, equals(expectedNext.outerHtml));
-      expect(commit.text + engine.buffer.text, equals(root.text));
     });
 
     test(


### PR DESCRIPTION
When splitting words during reflow, the whitespace prefix would linger on the paragraph split to the next page, causing the first sentence of the new subpage to start with a whitespace. Depending on the epub and css the whitespace would actually be visible.