### PR TITLE
fix: query error when series deleted during sync

### DIFF
--- a/lib/database/dao/series_dao.dart
+++ b/lib/database/dao/series_dao.dart
@@ -29,10 +29,10 @@ class SeriesDao extends DatabaseAccessor<AppDatabase> with _$SeriesDaoMixin {
   SeriesDao(super.attachedDatabase);
 
   /// Watch series [seriesId]
-  Stream<SeriesData> watchSeries(int seriesId) {
+  Stream<SeriesData?> watchSeries(int seriesId) {
     return managers.series
         .filter((s) => s.id(seriesId))
-        .watchSingle(distinct: true);
+        .watchSingleOrNull(distinct: true);
   }
 
   /// Search series by [query].

--- a/lib/riverpod/repository/series_repository.dart
+++ b/lib/riverpod/repository/series_repository.dart
@@ -10,6 +10,7 @@ import 'package:kover/sync/series_sync_operations.dart';
 import 'package:kover/sync/volume_sync_operations.dart';
 import 'package:kover/utils/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:rxdart/rxdart.dart';
 
 part 'series_repository.g.dart';
 
@@ -55,6 +56,7 @@ class SeriesRepository {
   Stream<SeriesModel> watchSeries(int seriesId) {
     return _db.seriesDao
         .watchSeries(seriesId)
+        .whereNotNull()
         .map(SeriesModel.fromDatabaseModel);
   }
 


### PR DESCRIPTION
If a series got yeeted during sync while the respective card was rendered in a grid, the query would throw an unhandled exception.