### PR TITLE
fix: progress sync failing on large libraries

### DIFF
--- a/lib/riverpod/repository/reader_repository.dart
+++ b/lib/riverpod/repository/reader_repository.dart
@@ -5,7 +5,9 @@ import 'package:kover/models/progress_model.dart';
 import 'package:kover/riverpod/providers/client.dart';
 import 'package:kover/riverpod/repository/database.dart';
 import 'package:kover/sync/reader_sync_operations.dart';
+import 'package:kover/utils/extensions/iterable.dart';
 import 'package:kover/utils/logging.dart';
+import 'package:pool/pool.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'reader_repository.g.dart';
@@ -161,15 +163,16 @@ class ReaderRepository {
   /// Refresh complete progress for all series that have newer reading progress
   /// than local
   Future<void> refreshOutdatedProgress() async {
-    final batch = <ReadingProgressCompanion>[];
     final outdated = await _db.readerDao.getOutdatedChapterIds();
+    final pool = Pool(8);
 
-    for (final c in outdated) {
-      final progress = await _readerClient.getProgress(c);
-      batch.add(progress);
+    for (final chunk in outdated.chunked(48)) {
+      final batch = await Future.wait(
+        chunk.map((b) => pool.withResource(() => _readerClient.getProgress(b))),
+      );
+
+      await _db.readerDao.mergeProgressBatch(batch);
     }
-
-    await _db.readerDao.mergeProgressBatch(batch);
   }
 
   /// Synchronize all dirty progress entries by sending them to the backend,

--- a/lib/utils/extensions/iterable.dart
+++ b/lib/utils/extensions/iterable.dart
@@ -9,4 +9,17 @@ extension IterableExtension<T> on Iterable<T> {
       yield it.current;
     }
   }
+
+  /// Splits the iterable into chunks of the given size.
+  /// If the iterable's length is not divisible by the chunk size, the last
+  /// chunk will contain  the remaining elements.
+  /// If the iterable is empty, an empty iterable is returned.
+  Iterable<Iterable<T>> chunked(int chuckSize) {
+    final result = <Iterable<T>>[];
+    for (var i = 0; i < length; i += chuckSize) {
+      result.add(skip(i).take(chuckSize));
+    }
+
+    return result;
+  }
 }

--- a/test/utils/extensions/iterable_test.dart
+++ b/test/utils/extensions/iterable_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kover/utils/extensions/iterable.dart';
+
+void main() {
+  group('chunked', () {
+    test('when empty iterable, then return empty list', () {
+      final iterable = <int>[];
+      final result = iterable.chunked(3);
+      expect(result, isEmpty);
+    });
+
+    test(
+      'when smaller than chunk size, then returns whole list in first chunk',
+      () {
+        final iterable = [1, 2];
+        final expected = [
+          [1, 2],
+        ];
+        final result = iterable.chunked(3);
+        expect(const DeepCollectionEquality().equals(result, expected), isTrue);
+      },
+    );
+
+    test('when bigger than chunk size, then should return split list', () {
+      final iterable = [1, 2, 3, 4];
+      final expected = [
+        [1, 2],
+        [3, 4],
+      ];
+      final result = iterable.chunked(2);
+      expect(const DeepCollectionEquality().equals(result, expected), isTrue);
+    });
+
+    test(
+      'when length is not divisible by chunk size, then no elements are lost',
+      () {
+        final iterable = [1, 2, 3, 4, 5];
+        final expected = [
+          [1, 2],
+          [3, 4],
+          [5],
+        ];
+        final result = iterable.chunked(2);
+        expect(const DeepCollectionEquality().equals(result, expected), isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
The latest progress sync improvements introduced some issues:

- when trying to sync a large amount of chapters, writing to the db could fail due to too many parameters passed to the query.
- iterative fetching made the sync take forever, as well as being completely lost if interrupted.

Fix by chunking up the outdated chapters before fetching, writing every batch to the db. This way, if sync is interrupted, not all fetched progress is lost, and the write query is not overwhelmed. Also allow some level of concurrent fetching to improve the sync performance.