### PR TITLE
fix: vertical epub reader gaps mid-paragraph

### DIFF
--- a/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
@@ -111,7 +111,6 @@ class const EpubHorizontalSubpages({
           html: data.reflow.subpages[index].outerHtml,
           styles: data.reflow.page.styles,
           imageCache: imageCache,
-          verticalPadding: true,
         ),
       );
     }
@@ -120,8 +119,6 @@ class const EpubHorizontalSubpages({
       controller: controller,
       allowImplicitScrolling: true,
       scrollCacheExtent: const .viewport(4),
-      scrollDirection: .horizontal,
-      clipBehavior: .none,
       reverse: data.reverse,
       itemCount: spreads ? spreadCount : count,
       physics: scrollPhysics,

--- a/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
@@ -5,7 +5,6 @@ import 'package:kover/riverpod/providers/reader/epub_reader.dart';
 import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
 import 'package:kover/utils/cached_image_factory.dart';
 import 'package:kover/utils/layout_constants.dart';
-import 'package:kover/widgets/util/async_value.dart';
 import 'package:material_ui/material_ui.dart';
 
 class const EpubHorizontalSubpages({
@@ -29,137 +28,127 @@ class const EpubHorizontalSubpages({
       seriesId: seriesId,
       chapterId: chapterId,
     );
+    final data = subpageState.requireValue;
 
-    return Async(
-      asyncValue: subpageState,
-      data: (data) {
-        return HookConsumer(
-          builder: (context, ref, _) {
-            final spreads = data.mode == .spreads;
-            final controller = usePageController(
-              initialPage: spreads
-                  ? data.navigation.subpage ~/ 2
-                  : data.navigation.subpage,
-            );
+    final spreads = data.mode == .spreads;
+    final controller = usePageController(
+      initialPage: spreads
+          ? data.navigation.subpage ~/ 2
+          : data.navigation.subpage,
+    );
 
-            // include buffer spinner page if currently measuring.
-            final count = data.reflow.status == .measuring
-                ? data.reflow.subpages.length + 1
-                : data.reflow.subpages.length;
-            final spreadCount = (count + 1) ~/ 2;
+    // include buffer spinner page if currently measuring.
+    final count = data.reflow.status == .measuring
+        ? data.reflow.subpages.length + 1
+        : data.reflow.subpages.length;
+    final spreadCount = (count + 1) ~/ 2;
 
-            final readDirection = ref.watch(
-              commonReaderSettingsProvider(
-                seriesId: seriesId,
-              ).select(
-                (value) => value.requireValue.readDirection,
-              ),
-            );
+    final readDirection = ref.watch(
+      commonReaderSettingsProvider(
+        seriesId: seriesId,
+      ).select(
+        (value) => value.requireValue.readDirection,
+      ),
+    );
 
-            final canScroll = data.gesturesEnabled && !data.reduceAnimations;
-            final scrollPhysics = canScroll
-                ? const AlwaysScrollableScrollPhysics(
-                    parent: ClampingScrollPhysics(),
-                  )
-                : const NeverScrollableScrollPhysics();
+    final canScroll = data.navigationGesturesEnabled && !data.reduceAnimations;
+    final scrollPhysics = canScroll
+        ? const AlwaysScrollableScrollPhysics(
+            parent: ClampingScrollPhysics(),
+          )
+        : const NeverScrollableScrollPhysics();
 
-            ref.listen(
-              navigationProvider.select(
-                (state) => state.whenData(
-                  (data) {
-                    if (data.page != page || data.fromObserver) return null;
+    ref.listen(
+      navigationProvider.select(
+        (state) => state.whenData(
+          (data) {
+            if (data.page != page || data.fromObserver) return null;
 
-                    return spreads ? data.subpage ~/ 2 : data.subpage;
-                  },
-                ),
-              ),
-              (previous, next) async {
-                next.whenData((next) async {
-                  final previousSubpage = previous?.value;
-                  if (next == null || next == previousSubpage) {
-                    return;
-                  }
-
-                  if (controller.hasClients &&
-                      controller.page?.round() != next) {
-                    final isSequential =
-                        previousSubpage != null &&
-                        (next - previousSubpage).abs() == 1;
-
-                    isSequential && !data.reduceAnimations
-                        ? controller.animateToPage(
-                            next,
-                            duration: LayoutConstants.pageSlideDuration,
-                            curve: Curves.easeInOut,
-                          )
-                        : controller.jumpToPage(next);
-                  }
-                });
-              },
-            );
-
-            Widget buildColumn(int index) {
-              if (index >= data.reflow.subpages.length) {
-                if (data.reflow.status == .measuring &&
-                    index == data.reflow.subpages.length) {
-                  return const Center(
-                    child: CircularProgressIndicator(),
-                  );
-                }
-
-                return const SizedBox.shrink();
-              }
-
-              return OverflowBox(
-                maxHeight: double.infinity,
-                alignment: .topCenter,
-                child: RenderEpubContent(
-                  seriesId: seriesId,
-                  html: data.reflow.subpages[index].outerHtml,
-                  styles: data.reflow.page.styles,
-                  imageCache: imageCache,
-                  verticalPadding: true,
-                ),
-              );
-            }
-
-            return PageView.builder(
-              controller: controller,
-              allowImplicitScrolling: true,
-              scrollCacheExtent: const .viewport(4),
-              scrollDirection: .horizontal,
-              clipBehavior: .none,
-              reverse: data.reverse,
-              itemCount: spreads ? spreadCount : count,
-              physics: scrollPhysics,
-              onPageChanged: (newPage) {
-                if (data.navigation.page != page) return;
-
-                ref
-                    .read(navigationProvider.notifier)
-                    .jumpToSubpage(
-                      spreads ? newPage * 2 : newPage,
-                      fromObserver: true,
-                    );
-              },
-              itemBuilder: (context, index) {
-                if (!spreads) {
-                  return buildColumn(index);
-                }
-
-                return Row(
-                  textDirection: switch (readDirection) {
-                    .leftToRight => .ltr,
-                    .rightToLeft => .rtl,
-                  },
-                  children: [
-                    Expanded(child: buildColumn(index * 2)),
-                    Expanded(child: buildColumn(index * 2 + 1)),
-                  ],
-                );
-              },
-            );
+            return spreads ? data.subpage ~/ 2 : data.subpage;
           },
+        ),
+      ),
+      (previous, next) async {
+        next.whenData((next) async {
+          final previousSubpage = previous?.value;
+          if (next == null || next == previousSubpage) {
+            return;
+          }
+
+          if (controller.hasClients && controller.page?.round() != next) {
+            final isSequential =
+                previousSubpage != null && (next - previousSubpage).abs() == 1;
+
+            isSequential && !data.reduceAnimations
+                ? controller.animateToPage(
+                    next,
+                    duration: LayoutConstants.pageSlideDuration,
+                    curve: Curves.easeInOut,
+                  )
+                : controller.jumpToPage(next);
+          }
+        });
+      },
+    );
+
+    Widget buildColumn(int index) {
+      if (index >= data.reflow.subpages.length) {
+        if (data.reflow.status == .measuring &&
+            index == data.reflow.subpages.length) {
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+
+        return const SizedBox.shrink();
+      }
+
+      return OverflowBox(
+        maxHeight: double.infinity,
+        alignment: .topCenter,
+        child: RenderEpubContent(
+          seriesId: seriesId,
+          html: data.reflow.subpages[index].outerHtml,
+          styles: data.reflow.page.styles,
+          imageCache: imageCache,
+          verticalPadding: true,
+        ),
+      );
+    }
+
+    return PageView.builder(
+      controller: controller,
+      allowImplicitScrolling: true,
+      scrollCacheExtent: const .viewport(4),
+      scrollDirection: .horizontal,
+      clipBehavior: .none,
+      reverse: data.reverse,
+      itemCount: spreads ? spreadCount : count,
+      physics: scrollPhysics,
+      onPageChanged: (newPage) {
+        if (data.navigation.page != page) return;
+
+        ref
+            .read(navigationProvider.notifier)
+            .jumpToSubpage(
+              spreads ? newPage * 2 : newPage,
+              fromObserver: true,
+            );
+      },
+      itemBuilder: (context, index) {
+        if (!spreads) {
+          return buildColumn(index);
+        }
+
+        return Row(
+          textDirection: switch (readDirection) {
+            .leftToRight => .ltr,
+            .rightToLeft => .rtl,
+          },
+          children: [
+            Expanded(child: buildColumn(index * 2)),
+            Expanded(child: buildColumn(index * 2 + 1)),
+          ],
         );
       },
     );

--- a/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/pages/reader/epub_reader/render_epub_content.dart';
+import 'package:kover/riverpod/providers/reader/epub_reader.dart';
+import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
+import 'package:kover/utils/cached_image_factory.dart';
+import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/widgets/util/async_value.dart';
+import 'package:material_ui/material_ui.dart';
+
+class const EpubHorizontalSubpages({
+  super.key,
+  required final int seriesId,
+  required final int chapterId,
+  required final int page,
+  required final CachedImageFactory imageCache,
+}) extends HookConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final subpageState = ref.watch(
+      epubReaderSubpageProvider(
+        seriesId: seriesId,
+        chapterId: chapterId,
+        page: page,
+      ),
+    );
+
+    final navigationProvider = epubNavigationProvider(
+      seriesId: seriesId,
+      chapterId: chapterId,
+    );
+
+    return Async(
+      asyncValue: subpageState,
+      data: (data) {
+        return HookConsumer(
+          builder: (context, ref, _) {
+            final spreads = data.mode == .spreads;
+            final controller = usePageController(
+              initialPage: spreads
+                  ? data.navigation.subpage ~/ 2
+                  : data.navigation.subpage,
+            );
+
+            // include buffer spinner page if currently measuring.
+            final count = data.reflow.status == .measuring
+                ? data.reflow.subpages.length + 1
+                : data.reflow.subpages.length;
+            final spreadCount = (count + 1) ~/ 2;
+
+            final readDirection = ref.watch(
+              commonReaderSettingsProvider(
+                seriesId: seriesId,
+              ).select(
+                (value) => value.requireValue.readDirection,
+              ),
+            );
+
+            final canScroll = data.gesturesEnabled && !data.reduceAnimations;
+            final scrollPhysics = canScroll
+                ? const AlwaysScrollableScrollPhysics(
+                    parent: ClampingScrollPhysics(),
+                  )
+                : const NeverScrollableScrollPhysics();
+
+            ref.listen(
+              navigationProvider.select(
+                (state) => state.whenData(
+                  (data) {
+                    if (data.page != page || data.fromObserver) return null;
+
+                    return spreads ? data.subpage ~/ 2 : data.subpage;
+                  },
+                ),
+              ),
+              (previous, next) async {
+                next.whenData((next) async {
+                  final previousSubpage = previous?.value;
+                  if (next == null || next == previousSubpage) {
+                    return;
+                  }
+
+                  if (controller.hasClients &&
+                      controller.page?.round() != next) {
+                    final isSequential =
+                        previousSubpage != null &&
+                        (next - previousSubpage).abs() == 1;
+
+                    isSequential && !data.reduceAnimations
+                        ? controller.animateToPage(
+                            next,
+                            duration: LayoutConstants.pageSlideDuration,
+                            curve: Curves.easeInOut,
+                          )
+                        : controller.jumpToPage(next);
+                  }
+                });
+              },
+            );
+
+            Widget buildColumn(int index) {
+              if (index >= data.reflow.subpages.length) {
+                if (data.reflow.status == .measuring &&
+                    index == data.reflow.subpages.length) {
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+
+                return const SizedBox.shrink();
+              }
+
+              return OverflowBox(
+                maxHeight: double.infinity,
+                alignment: .topCenter,
+                child: RenderEpubContent(
+                  seriesId: seriesId,
+                  html: data.reflow.subpages[index].outerHtml,
+                  styles: data.reflow.page.styles,
+                  imageCache: imageCache,
+                  verticalPadding: true,
+                ),
+              );
+            }
+
+            return PageView.builder(
+              controller: controller,
+              allowImplicitScrolling: true,
+              scrollCacheExtent: const .viewport(4),
+              scrollDirection: .horizontal,
+              clipBehavior: .none,
+              reverse: data.reverse,
+              itemCount: spreads ? spreadCount : count,
+              physics: scrollPhysics,
+              onPageChanged: (newPage) {
+                if (data.navigation.page != page) return;
+
+                ref
+                    .read(navigationProvider.notifier)
+                    .jumpToSubpage(
+                      spreads ? newPage * 2 : newPage,
+                      fromObserver: true,
+                    );
+              },
+              itemBuilder: (context, index) {
+                if (!spreads) {
+                  return buildColumn(index);
+                }
+
+                return Row(
+                  textDirection: switch (readDirection) {
+                    .leftToRight => .ltr,
+                    .rightToLeft => .rtl,
+                  },
+                  children: [
+                    Expanded(child: buildColumn(index * 2)),
+                    Expanded(child: buildColumn(index * 2 + 1)),
+                  ],
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/reader/epub_reader/epub_reader.dart
+++ b/lib/pages/reader/epub_reader/epub_reader.dart
@@ -316,12 +316,14 @@ class _Page extends HookConsumerWidget {
                 : null,
             child: vertical
                 ? EpubVerticalSubpages(
+                    key: ValueKey(page),
                     seriesId: seriesId,
                     chapterId: chapterId,
                     page: page,
                     imageCache: imageCache,
                   )
                 : EpubHorizontalSubpages(
+                    key: ValueKey(page),
                     seriesId: seriesId,
                     chapterId: chapterId,
                     page: page,

--- a/lib/pages/reader/epub_reader/epub_reader.dart
+++ b/lib/pages/reader/epub_reader/epub_reader.dart
@@ -251,85 +251,83 @@ class _Page extends HookConsumerWidget {
       chapterId: chapterId,
       page: page,
     );
-    final reflow = ref.watch(provider);
-    final navigationProvider = epubNavigationProvider(
-      seriesId: seriesId,
-      chapterId: chapterId,
-    );
-    final navigation = ref.watch(navigationProvider);
 
-    final navigationGestures = ref.watch(
-      commonReaderSettingsProvider(
+    final subpageState = ref.watch(
+      epubReaderSubpageProvider(
         seriesId: seriesId,
-      ).select(
-        (value) =>
-            value.whenOrNull(data: (data) => data.navigationGersturesEnabled) ??
-            false,
+        chapterId: chapterId,
+        page: page,
       ),
     );
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final isVisiblePage = navigation.value?.page == page;
-        final visibleReady = navigation.value?.ready ?? false;
-        final shouldStart = isVisiblePage || visibleReady;
+    return Async(
+      asyncValue: subpageState,
+      skipLoadingOnReload: true,
+      data: (data) {
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final isVisiblePage = data.navigation.page == page;
+            final visibleReady = data.navigation.ready;
+            final shouldStart = isVisiblePage || visibleReady;
 
-        if (shouldStart && reflow.value?.status != .done) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (!context.mounted) return;
-            ref
-                .read(provider.notifier)
-                .startReflow(
-                  viewport: spreads
-                      ? Size(
-                          constraints.maxWidth / 2,
-                          constraints.maxHeight,
-                        )
-                      : constraints.biggest,
-                  devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
-                  measureBuilder: (html, styles) => EpubMeasureRoot(
-                    container: container,
-                    mediaQueryData: mediaQueryData,
-                    themeData: themeData,
-                    textDirection: textDirection,
-                    locale: locale,
-                    seriesId: seriesId,
-                    html: html,
-                    styles: styles,
-                    imageCache: imageCache,
-                    verticalPadding: !vertical,
-                  ),
-                  refreshRate: View.of(context).display.refreshRate,
+            if (shouldStart && data.reflow.status != .done) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!context.mounted) return;
+                ref
+                    .read(provider.notifier)
+                    .startReflow(
+                      viewport: spreads
+                          ? Size(
+                              constraints.maxWidth / 2,
+                              constraints.maxHeight,
+                            )
+                          : constraints.biggest,
+                      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+                      measureBuilder: (html, styles) => EpubMeasureRoot(
+                        container: container,
+                        mediaQueryData: mediaQueryData,
+                        themeData: themeData,
+                        textDirection: textDirection,
+                        locale: locale,
+                        seriesId: seriesId,
+                        html: html,
+                        styles: styles,
+                        imageCache: imageCache,
+                        verticalPadding: !vertical,
+                      ),
+                      refreshRate: View.of(context).display.refreshRate,
+                    );
+              });
+            }
+
+            return SelectionArea(
+              onSelectionChanged: (selection) {
+                onSelectionChanged?.call(
+                  selection != null && selection.plainText.isNotEmpty,
                 );
-          });
-        }
-
-        return SelectionArea(
-          onSelectionChanged: (selection) {
-            onSelectionChanged?.call(
-              selection != null && selection.plainText.isNotEmpty,
+              },
+              child: NotificationListener<ScrollNotification>(
+                onNotification: data.navigationGesturesEnabled
+                    ? handleScrollNotification
+                    : null,
+                child: vertical
+                    ? EpubVerticalSubpages(
+                        key: ValueKey(page),
+                        seriesId: seriesId,
+                        chapterId: chapterId,
+                        page: page,
+                        imageCache: imageCache,
+                      )
+                    : EpubHorizontalSubpages(
+                        key: ValueKey(page),
+                        seriesId: seriesId,
+                        chapterId: chapterId,
+                        page: page,
+                        imageCache: imageCache,
+                      ),
+              ),
             );
           },
-          child: NotificationListener<ScrollNotification>(
-            onNotification: navigationGestures
-                ? handleScrollNotification
-                : null,
-            child: vertical
-                ? EpubVerticalSubpages(
-                    key: ValueKey(page),
-                    seriesId: seriesId,
-                    chapterId: chapterId,
-                    page: page,
-                    imageCache: imageCache,
-                  )
-                : EpubHorizontalSubpages(
-                    key: ValueKey(page),
-                    seriesId: seriesId,
-                    chapterId: chapterId,
-                    page: page,
-                    imageCache: imageCache,
-                  ),
-          ),
         );
       },
     );

--- a/lib/pages/reader/epub_reader/epub_reader.dart
+++ b/lib/pages/reader/epub_reader/epub_reader.dart
@@ -1,10 +1,11 @@
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/pages/reader/epub_reader/epub_horizontal_subpages.dart';
 import 'package:kover/pages/reader/epub_reader/epub_measure_root.dart';
 import 'package:kover/pages/reader/epub_reader/epub_toc_drawer.dart';
-import 'package:kover/pages/reader/epub_reader/render_epub_content.dart';
 import 'package:kover/pages/reader/epub_reader/epub_theme_override.dart';
+import 'package:kover/pages/reader/epub_reader/epub_vertical_subpages.dart';
 import 'package:kover/pages/reader/overlay/reader_overlay.dart';
 import 'package:kover/riverpod/providers/reader/epub_reader.dart';
 import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
@@ -261,25 +262,9 @@ class _Page extends HookConsumerWidget {
       commonReaderSettingsProvider(
         seriesId: seriesId,
       ).select(
-        (value) => value.whenData((data) => data.navigationGersturesEnabled),
-      ),
-    );
-
-    final readDirection = ref.watch(
-      commonReaderSettingsProvider(
-        seriesId: seriesId,
-      ).select(
-        (value) => value.requireValue.readDirection,
-      ),
-    );
-
-    final reduceAnimations = ref.watch(
-      themeProvider.select(
         (value) =>
-            value.whenOrNull(
-              data: (data) => data.reduceAnimations,
-            ) ??
-            const ThemeModel().reduceAnimations,
+            value.whenOrNull(data: (data) => data.navigationGersturesEnabled) ??
+            false,
       ),
     );
 
@@ -319,145 +304,30 @@ class _Page extends HookConsumerWidget {
           });
         }
 
-        return Async3(
-          asyncValue1: navigation,
-          asyncValue2: reflow,
-          asyncValue3: navigationGestures,
-          data: (navigationState, reflowState, navigationGestures) {
-            // include buffer spinner page if currently measuring.
-            final count = reflowState.status == .measuring
-                ? reflowState.subpages.length + 1
-                : reflowState.subpages.length;
-            final spreadCount = (count + 1) ~/ 2;
-
-            return HookConsumer(
-              builder: (context, ref, child) {
-                final controller = usePageController(
-                  initialPage: spreads
-                      ? navigationState.subpage ~/ 2
-                      : navigationState.subpage,
-                );
-                final bool canScroll =
-                    navigationGestures &&
-                    (!reduceAnimations || mode == .vertical);
-                final scrollPhysics = canScroll
-                    ? const AlwaysScrollableScrollPhysics(
-                        parent: ClampingScrollPhysics(),
-                      )
-                    : const NeverScrollableScrollPhysics();
-
-                ref.listen(
-                  navigationProvider.select(
-                    (state) => state.whenData(
-                      (data) {
-                        if (data.page != page || data.fromObserver) return null;
-
-                        return spreads ? data.subpage ~/ 2 : data.subpage;
-                      },
-                    ),
-                  ),
-                  (previous, next) async {
-                    next.whenData((next) async {
-                      final previousSubpage = previous?.value;
-                      if (next == null || next == previousSubpage) {
-                        return;
-                      }
-
-                      if (controller.hasClients &&
-                          controller.page?.round() != next) {
-                        final isSequential =
-                            previousSubpage != null &&
-                            (next - previousSubpage).abs() == 1;
-
-                        isSequential && !reduceAnimations
-                            ? controller.animateToPage(
-                                next,
-                                duration: LayoutConstants.pageSlideDuration,
-                                curve: Curves.easeInOut,
-                              )
-                            : controller.jumpToPage(next);
-                      }
-                    });
-                  },
-                );
-
-                Widget buildColumn(int index) {
-                  if (index >= reflowState.subpages.length) {
-                    if (reflowState.status == .measuring &&
-                        index == reflowState.subpages.length) {
-                      return const Center(
-                        child: CircularProgressIndicator(),
-                      );
-                    }
-
-                    return const SizedBox.shrink();
-                  }
-
-                  return OverflowBox(
-                    maxHeight: double.infinity,
-                    alignment: .topCenter,
-                    child: RenderEpubContent(
-                      seriesId: seriesId,
-                      html: reflowState.subpages[index].outerHtml,
-                      styles: reflowState.page.styles,
-                      imageCache: imageCache,
-                      verticalPadding: !vertical,
-                    ),
-                  );
-                }
-
-                return SelectionArea(
-                  onSelectionChanged: (selection) {
-                    onSelectionChanged?.call(
-                      selection != null && selection.plainText.isNotEmpty,
-                    );
-                  },
-                  child: NotificationListener<ScrollNotification>(
-                    onNotification: navigationGestures
-                        ? handleScrollNotification
-                        : null,
-                    child: PageView.builder(
-                      controller: controller,
-                      allowImplicitScrolling: true,
-                      scrollCacheExtent: const .viewport(4),
-                      scrollDirection: vertical ? .vertical : .horizontal,
-                      pageSnapping: !vertical,
-                      clipBehavior: .none,
-                      reverse: reverse,
-                      itemCount: spreads ? spreadCount : count,
-                      physics: scrollPhysics,
-                      onPageChanged: (newPage) {
-                        if (navigationState.page != page) return;
-
-                        ref
-                            .read(navigationProvider.notifier)
-                            .jumpToSubpage(
-                              spreads ? newPage * 2 : newPage,
-                              fromObserver: true,
-                            );
-                      },
-                      itemBuilder: (context, index) {
-                        if (!spreads) {
-                          return buildColumn(index);
-                        }
-
-                        return Row(
-                          textDirection: switch (readDirection) {
-                            .leftToRight => .ltr,
-                            .rightToLeft => .rtl,
-                          },
-                          children: [
-                            Expanded(child: buildColumn(index * 2)),
-                            Expanded(child: buildColumn(index * 2 + 1)),
-                          ],
-                        );
-                      },
-                    ),
-                  ),
-                );
-              },
+        return SelectionArea(
+          onSelectionChanged: (selection) {
+            onSelectionChanged?.call(
+              selection != null && selection.plainText.isNotEmpty,
             );
           },
+          child: NotificationListener<ScrollNotification>(
+            onNotification: navigationGestures
+                ? handleScrollNotification
+                : null,
+            child: vertical
+                ? EpubVerticalSubpages(
+                    seriesId: seriesId,
+                    chapterId: chapterId,
+                    page: page,
+                    imageCache: imageCache,
+                  )
+                : EpubHorizontalSubpages(
+                    seriesId: seriesId,
+                    chapterId: chapterId,
+                    page: page,
+                    imageCache: imageCache,
+                  ),
+          ),
         );
       },
     );

--- a/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
@@ -114,8 +114,7 @@ class const EpubVerticalSubpages({
 
         final lastSubpage = data.reflow.subpages.length - 1;
 
-        // Bottom edge: report last subpage so progress + tap navigation
-        // behave as if the user reached the end.
+        // report last subpage on bottom edge
         if (model.displayingChildIndexList.contains(lastSubpage)) {
           ref
               .read(navigationProvider.notifier)
@@ -132,6 +131,7 @@ class const EpubVerticalSubpages({
       },
       child: CustomScrollView(
         controller: scrollController,
+        clipBehavior: .none,
         scrollCacheExtent: const .viewport(4),
         physics: const AlwaysScrollableScrollPhysics(
           parent: ClampingScrollPhysics(),

--- a/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
@@ -6,7 +6,6 @@ import 'package:kover/riverpod/providers/reader/epub_reader.dart';
 import 'package:kover/utils/cached_image_factory.dart';
 import 'package:kover/utils/hooks/use_sliver_observer_controller.dart';
 import 'package:kover/utils/layout_constants.dart';
-import 'package:kover/widgets/util/async_value.dart';
 import 'package:scrollview_observer/scrollview_observer.dart';
 
 class const EpubVerticalSubpages({
@@ -29,132 +28,121 @@ class const EpubVerticalSubpages({
         page: page,
       ),
     );
+    final data = subpageState.requireValue;
 
-    return Async(
-      asyncValue: subpageState,
-      data: (data) {
-        return HookConsumer(
-          builder: (context, ref, _) {
-            // include buffer spinner page if currently measuring.
-            final count = data.reflow.status == .measuring
-                ? data.reflow.subpages.length + 1
-                : data.reflow.subpages.length;
+    // include buffer spinner page if currently measuring.
+    final count = data.reflow.status == .measuring
+        ? data.reflow.subpages.length + 1
+        : data.reflow.subpages.length;
 
-            final scrollController = useScrollController();
-            final observerController = useSliverObserverController(
-              controller: scrollController,
-              initialIndex: data.navigation.subpage,
-            );
+    final scrollController = useScrollController();
+    final observerController = useSliverObserverController(
+      controller: scrollController,
+      initialIndex: data.navigation.subpage,
+    );
 
-            ref.listen(
-              navigationProvider.select(
-                (state) => state.whenData(
-                  (data) {
-                    if (data.page != page || data.fromObserver) return null;
+    ref.listen(
+      navigationProvider.select(
+        (state) => state.whenData(
+          (data) {
+            if (data.page != page || data.fromObserver) return null;
 
-                    return data.subpage;
-                  },
-                ),
-              ),
-              (previous, next) async {
-                next.whenData((next) async {
-                  final previousSubpage = previous?.value;
-                  if (next == null ||
-                      next == previousSubpage ||
-                      !scrollController.hasClients ||
-                      count == 0) {
-                    return;
-                  }
-
-                  final target = next.clamp(0, count - 1);
-
-                  final isSequential =
-                      previousSubpage != null &&
-                      (target - previousSubpage).abs() == 1;
-
-                  isSequential && !data.reduceAnimations
-                      ? await observerController.animateTo(
-                          index: target,
-                          duration: LayoutConstants.pageSlideDuration,
-                          curve: Curves.easeInOut,
-                        )
-                      : await observerController.jumpTo(index: target);
-                });
-              },
-            );
-
-            Widget buildItem(int index) {
-              final Widget content =
-                  data.reflow.status == .measuring &&
-                      index >= data.reflow.subpages.length
-                  ? const Center(
-                      child: CircularProgressIndicator(),
-                    )
-                  : RenderEpubContent(
-                      seriesId: seriesId,
-                      html: data.reflow.subpages[index].outerHtml,
-                      styles: data.reflow.page.styles,
-                      imageCache: imageCache,
-                      verticalPadding: false,
-                    );
-
-              return ConstrainedBox(
-                constraints: BoxConstraints(
-                  minHeight:
-                      MediaQuery.of(context).size.height -
-                      data.paragraphSpacing,
-                ),
-                child: content,
-              );
-            }
-
-            return SliverViewObserver(
-              controller: observerController,
-              onObserve: (ObserveModel model) {
-                if (model is! ListViewObserveModel ||
-                    data.navigation.page != page ||
-                    data.reflow.status == .measuring) {
-                  return;
-                }
-
-                final firstVisibleIndex = model.firstChild?.index;
-                if (firstVisibleIndex == null) return;
-
-                final lastSubpage = data.reflow.subpages.length - 1;
-
-                // Bottom edge: report last subpage so progress + tap navigation
-                // behave as if the user reached the end.
-                if (model.displayingChildIndexList.contains(lastSubpage)) {
-                  ref
-                      .read(navigationProvider.notifier)
-                      .jumpToSubpage(lastSubpage, fromObserver: true);
-                  return;
-                }
-
-                ref
-                    .read(navigationProvider.notifier)
-                    .jumpToSubpage(
-                      firstVisibleIndex.clamp(0, lastSubpage),
-                      fromObserver: true,
-                    );
-              },
-              child: CustomScrollView(
-                controller: scrollController,
-                scrollCacheExtent: const .viewport(4),
-                physics: const AlwaysScrollableScrollPhysics(
-                  parent: ClampingScrollPhysics(),
-                ),
-                slivers: [
-                  SliverList.builder(
-                    itemCount: count,
-                    itemBuilder: (context, index) => buildItem(index),
-                  ),
-                ],
-              ),
-            );
+            return data.subpage;
           },
-        );
+        ),
+      ),
+      (previous, next) async {
+        next.whenData((next) async {
+          final previousSubpage = previous?.value;
+          if (next == null ||
+              next == previousSubpage ||
+              !scrollController.hasClients ||
+              count == 0) {
+            return;
+          }
+
+          final target = next.clamp(0, count - 1);
+
+          final isSequential =
+              previousSubpage != null && (target - previousSubpage).abs() == 1;
+
+          isSequential && !data.reduceAnimations
+              ? await observerController.animateTo(
+                  index: target,
+                  duration: LayoutConstants.pageSlideDuration,
+                  curve: Curves.easeInOut,
+                )
+              : await observerController.jumpTo(index: target);
+        });
       },
+    );
+
+    Widget buildItem(int index) {
+      final Widget content =
+          data.reflow.status == .measuring &&
+              index >= data.reflow.subpages.length
+          ? const Center(
+              child: CircularProgressIndicator(),
+            )
+          : RenderEpubContent(
+              seriesId: seriesId,
+              html: data.reflow.subpages[index].outerHtml,
+              styles: data.reflow.page.styles,
+              imageCache: imageCache,
+              verticalPadding: false,
+            );
+
+      return ConstrainedBox(
+        constraints: BoxConstraints(
+          minHeight: MediaQuery.of(context).size.height - data.paragraphSpacing,
+        ),
+        child: content,
+      );
+    }
+
+    return SliverViewObserver(
+      controller: observerController,
+      onObserve: (ObserveModel model) {
+        if (model is! ListViewObserveModel ||
+            data.navigation.page != page ||
+            data.reflow.status == .measuring) {
+          return;
+        }
+
+        final firstVisibleIndex = model.firstChild?.index;
+        if (firstVisibleIndex == null) return;
+
+        final lastSubpage = data.reflow.subpages.length - 1;
+
+        // Bottom edge: report last subpage so progress + tap navigation
+        // behave as if the user reached the end.
+        if (model.displayingChildIndexList.contains(lastSubpage)) {
+          ref
+              .read(navigationProvider.notifier)
+              .jumpToSubpage(lastSubpage, fromObserver: true);
+          return;
+        }
+
+        ref
+            .read(navigationProvider.notifier)
+            .jumpToSubpage(
+              firstVisibleIndex.clamp(0, lastSubpage),
+              fromObserver: true,
+            );
+      },
+      child: CustomScrollView(
+        controller: scrollController,
+        scrollCacheExtent: const .viewport(4),
+        physics: const AlwaysScrollableScrollPhysics(
+          parent: ClampingScrollPhysics(),
+        ),
+        slivers: [
+          SliverList.builder(
+            itemCount: count,
+            itemBuilder: (context, index) => buildItem(index),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/pages/reader/epub_reader/render_epub_content.dart';
+import 'package:kover/riverpod/providers/reader/epub_reader.dart';
+import 'package:kover/utils/cached_image_factory.dart';
+import 'package:kover/utils/hooks/use_sliver_observer_controller.dart';
+import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/widgets/util/async_value.dart';
+import 'package:scrollview_observer/scrollview_observer.dart';
+
+class const EpubVerticalSubpages({
+  super.key,
+  required final int seriesId,
+  required final int chapterId,
+  required final int page,
+  required final CachedImageFactory imageCache,
+}) extends HookConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final navigationProvider = epubNavigationProvider(
+      seriesId: seriesId,
+      chapterId: chapterId,
+    );
+    final subpageState = ref.watch(
+      epubReaderSubpageProvider(
+        seriesId: seriesId,
+        chapterId: chapterId,
+        page: page,
+      ),
+    );
+
+    return Async(
+      asyncValue: subpageState,
+      data: (data) {
+        return HookConsumer(
+          builder: (context, ref, _) {
+            // include buffer spinner page if currently measuring.
+            final count = data.reflow.status == .measuring
+                ? data.reflow.subpages.length + 1
+                : data.reflow.subpages.length;
+
+            final scrollController = useScrollController();
+            final observerController = useSliverObserverController(
+              controller: scrollController,
+              initialIndex: data.navigation.subpage,
+            );
+
+            ref.listen(
+              navigationProvider.select(
+                (state) => state.whenData(
+                  (data) {
+                    if (data.page != page || data.fromObserver) return null;
+
+                    return data.subpage;
+                  },
+                ),
+              ),
+              (previous, next) async {
+                next.whenData((next) async {
+                  final previousSubpage = previous?.value;
+                  if (next == null ||
+                      next == previousSubpage ||
+                      !scrollController.hasClients ||
+                      count == 0) {
+                    return;
+                  }
+
+                  final target = next.clamp(0, count - 1);
+
+                  final isSequential =
+                      previousSubpage != null &&
+                      (target - previousSubpage).abs() == 1;
+
+                  isSequential && !data.reduceAnimations
+                      ? await observerController.animateTo(
+                          index: target,
+                          duration: LayoutConstants.pageSlideDuration,
+                          curve: Curves.easeInOut,
+                        )
+                      : await observerController.jumpTo(index: target);
+                });
+              },
+            );
+
+            Widget buildItem(int index) {
+              final Widget content =
+                  data.reflow.status == .measuring &&
+                      index >= data.reflow.subpages.length
+                  ? const Center(
+                      child: CircularProgressIndicator(),
+                    )
+                  : RenderEpubContent(
+                      seriesId: seriesId,
+                      html: data.reflow.subpages[index].outerHtml,
+                      styles: data.reflow.page.styles,
+                      imageCache: imageCache,
+                      verticalPadding: false,
+                    );
+
+              return ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight:
+                      MediaQuery.of(context).size.height -
+                      data.paragraphSpacing,
+                ),
+                child: content,
+              );
+            }
+
+            return SliverViewObserver(
+              controller: observerController,
+              onObserve: (ObserveModel model) {
+                if (model is! ListViewObserveModel ||
+                    data.navigation.page != page ||
+                    data.reflow.status == .measuring) {
+                  return;
+                }
+
+                final firstVisibleIndex = model.firstChild?.index;
+                if (firstVisibleIndex == null) return;
+
+                final lastSubpage = data.reflow.subpages.length - 1;
+
+                // Bottom edge: report last subpage so progress + tap navigation
+                // behave as if the user reached the end.
+                if (model.displayingChildIndexList.contains(lastSubpage)) {
+                  ref
+                      .read(navigationProvider.notifier)
+                      .jumpToSubpage(lastSubpage, fromObserver: true);
+                  return;
+                }
+
+                ref
+                    .read(navigationProvider.notifier)
+                    .jumpToSubpage(
+                      firstVisibleIndex.clamp(0, lastSubpage),
+                      fromObserver: true,
+                    );
+              },
+              child: CustomScrollView(
+                controller: scrollController,
+                scrollCacheExtent: const .viewport(4),
+                physics: const AlwaysScrollableScrollPhysics(
+                  parent: ClampingScrollPhysics(),
+                ),
+                slivers: [
+                  SliverList.builder(
+                    itemCount: count,
+                    itemBuilder: (context, index) => buildItem(index),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/reader/epub_reader/render_epub_content.dart
+++ b/lib/pages/reader/epub_reader/render_epub_content.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/riverpod/providers/book.dart';
 import 'package:kover/riverpod/providers/settings/epub_reader_settings.dart';
 import 'package:kover/utils/cached_image_factory.dart';
+import 'package:kover/utils/html_constants.dart';
 import 'package:kover/widgets/util/async_value.dart';
 
 class RenderEpubContent extends ConsumerWidget {
@@ -67,7 +68,11 @@ class RenderEpubContent extends ConsumerWidget {
                 final considerLast =
                     !verticalPadding || element.nextElementSibling != null;
 
-                if (element.localName == 'p' && considerLast) {
+                final isSplit = element.attributes.containsKey(
+                  HtmlConstants.splitParagraphAttribute,
+                );
+
+                if (element.localName == 'p' && considerLast && !isSplit) {
                   final paragraphMargin =
                       'margin-bottom: ${epubSettings.paragraphSpacing}px';
 

--- a/lib/pages/reader/image_reader/vertical_continuous_reader.dart
+++ b/lib/pages/reader/image_reader/vertical_continuous_reader.dart
@@ -9,48 +9,10 @@ import 'package:kover/riverpod/providers/book.dart';
 import 'package:kover/riverpod/providers/reader/image_vertical_reader.dart';
 import 'package:kover/riverpod/providers/reader/reader_navigation.dart';
 import 'package:kover/riverpod/providers/settings/image_reader_settings.dart';
+import 'package:kover/utils/hooks/use_sliver_observer_controller.dart';
 import 'package:kover/utils/layout_constants.dart';
 import 'package:kover/widgets/util/async_value.dart';
 import 'package:scrollview_observer/scrollview_observer.dart';
-
-class SliverObserverControllerHook extends Hook<SliverObserverController> {
-  final ScrollController? controller;
-  final int? initialIndex;
-
-  const SliverObserverControllerHook({this.controller, this.initialIndex});
-
-  @override
-  SliverObserverControllerHookState createState() =>
-      SliverObserverControllerHookState();
-}
-
-class SliverObserverControllerHookState
-    extends HookState<SliverObserverController, SliverObserverControllerHook> {
-  late final SliverObserverController controller;
-
-  @override
-  void initHook() {
-    super.initHook();
-    controller = SliverObserverController(controller: hook.controller)
-      ..initialIndexModelBlock = hook.initialIndex != null
-          ? () => ObserverIndexPositionModel(index: hook.initialIndex!)
-          : null
-      ..cacheJumpIndexOffset = false;
-  }
-
-  @override
-  SliverObserverController build(BuildContext context) => controller;
-}
-
-SliverObserverController useSliverObserverController({
-  ScrollController? controller,
-  int? initialIndex,
-}) => use(
-  SliverObserverControllerHook(
-    controller: controller,
-    initialIndex: initialIndex,
-  ),
-);
 
 class VerticalContinuousReader extends HookConsumerWidget {
   final int seriesId;

--- a/lib/riverpod/providers/reader/epub_reader.dart
+++ b/lib/riverpod/providers/reader/epub_reader.dart
@@ -51,10 +51,6 @@ sealed class EpubReflowState with _$EpubReflowState {
 class EpubReflow extends _$EpubReflow {
   final _pipeline = HeadlessMeasurePipeline();
 
-  // The scroll-id to seek to on resume. Set once from the DB on the very
-  // first build and cleared as soon as we reach a Display state, so that
-  // subsequent page-turn rebuilds never re-trigger a seek.
-  String? _resumeScrollId;
   bool _measuring = false;
   late EpubMeasureWidgetBuilder _measureBuilder;
   late Duration _maxChunkDuration;
@@ -98,8 +94,9 @@ class EpubReflow extends _$EpubReflow {
     final settings = await settingsFuture;
     final pageContent = await pageContentFuture;
 
+    String? resumeScrollId;
     if (progress != null && page == progress.pageNum) {
-      _resumeScrollId = progress.bookScrollId;
+      resumeScrollId = progress.bookScrollId;
     }
 
     for (final family in pageContent.fonts.entries) {
@@ -112,9 +109,9 @@ class EpubReflow extends _$EpubReflow {
       await loader.load();
     }
 
-    if (settings.highlightResumePoint && _resumeScrollId != null) {
+    if (settings.highlightResumePoint && resumeScrollId != null) {
       final resumePoint = pageContent.root.querySelector(
-        '[${HtmlConstants.scrollIdAttribute}="${_resumeScrollId!.cssEscaped}"]',
+        '[${HtmlConstants.scrollIdAttribute}="${resumeScrollId.cssEscaped}"]',
       );
       if (resumePoint != null && resumePoint.hasChildNodes()) {
         resumePoint.classes.add(HtmlConstants.resumeParagraphClass);
@@ -125,7 +122,7 @@ class EpubReflow extends _$EpubReflow {
 
     return EpubReflowState(
       page: pageContent,
-      scrollId: _resumeScrollId,
+      scrollId: resumeScrollId,
     );
   }
 
@@ -346,7 +343,6 @@ class EpubNavigation extends _$EpubNavigation {
 
     _handleNavigationProviderChanges();
     _handleProgress();
-    _handleSettingsChanges();
 
     return EpubNavigationState(
       page: reader.initialPage,
@@ -354,37 +350,6 @@ class EpubNavigation extends _$EpubNavigation {
       subpage: 0,
       totalSubpages: 0,
     );
-  }
-
-  void _handleSettingsChanges() {
-    listenSelf((prev, next) {
-      next.whenData((data) {
-        if (prev?.value?.page == data.page) {
-          return;
-        }
-
-        ref.listen(
-          epubReflowProvider(
-            seriesId: seriesId,
-            chapterId: chapterId,
-            page: data.page,
-          ),
-          (prev, next) {
-            next.whenData((next) {
-              if (next.status == .measuring && prev?.value?.status == .done) {
-                state = AsyncData(
-                  data.copyWith(
-                    ready: false,
-                    subpage: 0,
-                    totalSubpages: next.subpages.length,
-                  ),
-                );
-              }
-            });
-          },
-        );
-      });
-    });
   }
 
   void _handleProgress() {
@@ -502,6 +467,11 @@ class EpubNavigation extends _$EpubNavigation {
         page: page,
       ),
       (prev, next) {
+        if (next.isLoading && prev?.hasValue == true) {
+          _resumed = false;
+          ref.invalidateSelf(asReload: true);
+          return;
+        }
         next.whenData((data) async {
           final current = await future;
 

--- a/lib/riverpod/providers/reader/epub_reader.dart
+++ b/lib/riverpod/providers/reader/epub_reader.dart
@@ -10,7 +10,9 @@ import 'package:kover/riverpod/providers/book.dart';
 import 'package:kover/riverpod/providers/reader.dart';
 import 'package:kover/riverpod/providers/reader//reader.dart';
 import 'package:kover/riverpod/providers/reader/reader_navigation.dart';
+import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
 import 'package:kover/riverpod/providers/settings/epub_reader_settings.dart';
+import 'package:kover/riverpod/providers/theme.dart';
 import 'package:kover/utils/extensions/document_fragment.dart';
 import 'package:kover/utils/extensions/string.dart';
 import 'package:kover/utils/html_constants.dart';
@@ -613,4 +615,68 @@ class EpubNavigation extends _$EpubNavigation {
     final current = await future;
     await jumpToSubpage(current.subpage - _step);
   }
+}
+
+@freezed
+sealed class EpubReaderSubpageState with _$EpubReaderSubpageState {
+  const factory EpubReaderSubpageState({
+    required EpubNavigationState navigation,
+    required EpubReflowState reflow,
+    required EpubReaderMode mode,
+    required double paragraphSpacing,
+    required bool reverse,
+    required bool gesturesEnabled,
+    required bool reduceAnimations,
+  }) = _EpubReaderSubpageState;
+}
+
+@riverpod
+Future<EpubReaderSubpageState> epubReaderSubpage(
+  Ref ref, {
+  required int seriesId,
+  required int chapterId,
+  required int page,
+}) async {
+  final navigationFuture = ref.watch(
+    epubNavigationProvider(
+      seriesId: seriesId,
+      chapterId: chapterId,
+    ).future,
+  );
+  final reflowFuture = ref.watch(
+    epubReflowProvider(
+      seriesId: seriesId,
+      chapterId: chapterId,
+      page: page,
+    ).future,
+  );
+  final epubSettingsFuture = ref.watch(
+    epubReaderSettingsProvider(seriesId: seriesId).selectAsync(
+      (value) => (value.mode, value.paragraphSpacing),
+    ),
+  );
+  final commonSettingsFuture = ref.watch(
+    commonReaderSettingsProvider(seriesId: seriesId).selectAsync(
+      (value) => (value.navigationGersturesEnabled, value.readDirection),
+    ),
+  );
+  final reduceAnimationsFuture = ref.watch(
+    themeProvider.selectAsync((value) => value.reduceAnimations),
+  );
+
+  final navigation = await navigationFuture;
+  final reflow = await reflowFuture;
+  final (mode, paragraphSpacing) = await epubSettingsFuture;
+  final (navigationGestures, readDirection) = await commonSettingsFuture;
+  final reduceAnimations = await reduceAnimationsFuture;
+
+  return EpubReaderSubpageState(
+    navigation: navigation,
+    reflow: reflow,
+    mode: mode,
+    paragraphSpacing: paragraphSpacing,
+    reverse: readDirection == .rightToLeft,
+    gesturesEnabled: navigationGestures,
+    reduceAnimations: reduceAnimations,
+  );
 }

--- a/lib/riverpod/providers/reader/epub_reader.dart
+++ b/lib/riverpod/providers/reader/epub_reader.dart
@@ -625,7 +625,7 @@ sealed class EpubReaderSubpageState with _$EpubReaderSubpageState {
     required EpubReaderMode mode,
     required double paragraphSpacing,
     required bool reverse,
-    required bool gesturesEnabled,
+    required bool navigationGesturesEnabled,
     required bool reduceAnimations,
   }) = _EpubReaderSubpageState;
 }
@@ -664,8 +664,8 @@ Future<EpubReaderSubpageState> epubReaderSubpage(
     themeProvider.selectAsync((value) => value.reduceAnimations),
   );
 
-  final navigation = await navigationFuture;
   final reflow = await reflowFuture;
+  final navigation = await navigationFuture;
   final (mode, paragraphSpacing) = await epubSettingsFuture;
   final (navigationGestures, readDirection) = await commonSettingsFuture;
   final reduceAnimations = await reduceAnimationsFuture;
@@ -676,7 +676,7 @@ Future<EpubReaderSubpageState> epubReaderSubpage(
     mode: mode,
     paragraphSpacing: paragraphSpacing,
     reverse: readDirection == .rightToLeft,
-    gesturesEnabled: navigationGestures,
+    navigationGesturesEnabled: navigationGestures,
     reduceAnimations: reduceAnimations,
   );
 }

--- a/lib/utils/hooks/use_sliver_observer_controller.dart
+++ b/lib/utils/hooks/use_sliver_observer_controller.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:scrollview_observer/scrollview_observer.dart';
+
+class SliverObserverControllerHook extends Hook<SliverObserverController> {
+  final ScrollController? controller;
+  final int? initialIndex;
+
+  const SliverObserverControllerHook({this.controller, this.initialIndex});
+
+  @override
+  SliverObserverControllerHookState createState() =>
+      SliverObserverControllerHookState();
+}
+
+class SliverObserverControllerHookState
+    extends HookState<SliverObserverController, SliverObserverControllerHook> {
+  late final SliverObserverController controller;
+
+  @override
+  void initHook() {
+    super.initHook();
+    controller = SliverObserverController(controller: hook.controller)
+      ..initialIndexModelBlock = hook.initialIndex != null
+          ? () => ObserverIndexPositionModel(index: hook.initialIndex!)
+          : null
+      ..cacheJumpIndexOffset = false;
+  }
+
+  @override
+  SliverObserverController build(BuildContext context) => controller;
+}
+
+SliverObserverController useSliverObserverController({
+  ScrollController? controller,
+  int? initialIndex,
+}) => use(
+  SliverObserverControllerHook(
+    controller: controller,
+    initialIndex: initialIndex,
+  ),
+);

--- a/lib/utils/html_constants.dart
+++ b/lib/utils/html_constants.dart
@@ -4,4 +4,5 @@ sealed class HtmlConstants {
   static const String kavitaWrapperClass = 'book-content';
   static const String koverWrapperClass = 'kover-content';
   static const String textIndentSpanAttribute = 'indent-span';
+  static const String splitParagraphAttribute = 'split-paragraph';
 }

--- a/lib/utils/reflow_engine.dart
+++ b/lib/utils/reflow_engine.dart
@@ -164,6 +164,18 @@ class BinaryReflowEngine implements ReflowEngine {
         .where((p) => !p.hasVisibleNodes)
         .forEach((p) => p.remove());
 
+    // Mark a trailing split paragraph so the renderer can omit its bottom
+    // margin: the split halves should read as one paragraph.
+    final hasSplitParagraph = _frames.any(
+      (f) => f.target.localName == 'p' && f.target.hasVisibleNodes,
+    );
+    if (hasSplitParagraph) {
+      final trailing = result.localName == 'p'
+          ? result
+          : result.querySelectorAll('p').lastOrNull;
+      trailing?.attributes[HtmlConstants.splitParagraphAttribute] = '';
+    }
+
     // Reconstruct a clear tree up to the deepest target.
     Element? parent;
     for (final f in _frames) {

--- a/lib/widgets/util/async_value.dart
+++ b/lib/widgets/util/async_value.dart
@@ -3,20 +3,14 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/utils/logging.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
-class Async<T> extends StatelessWidget {
-  final AsyncValue<T> asyncValue;
-  final Widget Function(T) data;
-  final Widget Function()? loading;
-  final Widget Function(Object, StackTrace)? error;
-
-  const Async({
-    super.key,
-    required this.asyncValue,
-    required this.data,
-    this.loading,
-    this.error,
-  });
-
+class const Async<T>({
+  super.key,
+  required final AsyncValue<T> asyncValue,
+  required final Widget Function(T) data,
+  final Widget Function()? loading,
+  final Widget Function(Object, StackTrace)? error,
+  final bool skipLoadingOnReload = false,
+}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return asyncValue.when(
@@ -29,6 +23,7 @@ class Async<T> extends StatelessWidget {
             error: error,
             stacktrace: stack,
           ),
+      skipLoadingOnReload: skipLoadingOnReload,
     );
   }
 }

--- a/test/utils/reflow_engine_test.dart
+++ b/test/utils/reflow_engine_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:html/dom.dart';
+import 'package:kover/utils/html_constants.dart';
 import 'package:kover/utils/reflow_engine.dart';
 
 void main() {
@@ -145,7 +146,11 @@ void main() {
         final root = Element.tag('div')
           ..append(Element.tag('p')..append(Text('Hello. There. Sentences.')));
         final expectedCommit = Element.tag('div')
-          ..append(Element.tag('p')..append(Text('Hello.')));
+          ..append(
+            Element.tag('p')
+              ..append(Text('Hello.'))
+              ..attributes[HtmlConstants.splitParagraphAttribute] = '',
+          );
         final expectedNext = Element.tag('div')
           ..append(Element.tag('p')..append(Text('There. Sentences.')));
 
@@ -178,7 +183,11 @@ void main() {
         final root = Element.tag('div')
           ..append(Element.tag('p')..append(Text('Hello. There. Sentences')));
         final expectedCommit = Element.tag('div')
-          ..append(Element.tag('p')..append(Text('Hello.')));
+          ..append(
+            Element.tag('p')
+              ..append(Text('Hello.'))
+              ..attributes[HtmlConstants.splitParagraphAttribute] = '',
+          );
         final expectedNext = Element.tag('div')
           ..append(Element.tag('p')..append(Text('There. Sentences')));
 
@@ -209,7 +218,11 @@ void main() {
       final root = Element.tag('div')
         ..append(Element.tag('p')..append(Text('"Hello." "There."')));
       final expectedCommit = Element.tag('div')
-        ..append(Element.tag('p')..append(Text('"Hello."')));
+        ..append(
+          Element.tag('p')
+            ..append(Text('"Hello."'))
+            ..attributes[HtmlConstants.splitParagraphAttribute] = '',
+        );
       final expectedNext = Element.tag('div')
         ..append(Element.tag('p')..append(Text('"There."')));
 
@@ -233,7 +246,9 @@ void main() {
       // <p>Hello there white space</p>
       final root = Element.tag('p')..append(Text('Hello there white space'));
       // The page-ending word carries no trailing whitespace ...
-      final expectedCommit = Element.tag('p')..append(Text('Hello there'));
+      final expectedCommit = Element.tag('p')
+        ..append(Text('Hello there'))
+        ..attributes[HtmlConstants.splitParagraphAttribute] = '';
       // ... it is kept on the following word: no whitespace is lost.
       final expectedNext = Element.tag('p')..append(Text('white space'));
 
@@ -280,5 +295,29 @@ void main() {
         expect(engine.addNext(), isFalse);
       },
     );
+
+    test('when split paragraph backtracks empty, no attribute is set', () {
+      // <div>
+      //   <p>Hello</p>
+      //   <p>there</p>
+      // </div>
+      final root = Element.tag('div')
+        ..append(Element.tag('p')..append(Text('Hello')))
+        ..append(Element.tag('p')..append(Text('there')));
+
+      final engine = BinaryReflowEngine(root: root);
+
+      engine.addNext(); // p1
+      engine.addNext(); // p2
+      engine.overflow(); // boundary: descend into p2 (empty clone)
+      engine.addNext(); // text 'there' appended to the clone
+      engine.overflow(); // single word overflows: unsplittable
+      final commit = engine.commitSplit(); // backtrack 'there', shell removed
+
+      expect(
+        commit.querySelector('p')?.attributes,
+        isNot(contains(HtmlConstants.splitParagraphAttribute)),
+      );
+    });
   });
 }


### PR DESCRIPTION
Due to the `PageView` fixed extents, when used in vertical mode, unexpected gaps may render in the middle of a paragraph due to the paragraph being split between subpages and the subpage not filling the whole vertical space. Moving the inner `PageView` to a `CustomScrollview` in vertical mode allows for dynamic extents and thus no unexpected gaps.