### PR TITLE
feat: add configurable reader keybinds options

### DIFF
--- a/android/app/src/main/kotlin/com/rodonisi/kover/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/rodonisi/kover/MainActivity.kt
@@ -1,5 +1,47 @@
 package com.rodonisi.kover
 
+import android.view.KeyEvent
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private var volumeKeySink: EventChannel.EventSink? = null
+    private val capturedKeyCodes = mutableSetOf<Int>()
+
+    private val volumeKeyChannel = object : EventChannel.StreamHandler {
+        override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+            volumeKeySink = events
+        }
+
+        override fun onCancel(arguments: Any?) {
+            volumeKeySink = null
+        }
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+        EventChannel(messenger, "kover/volume_keys").setStreamHandler(volumeKeyChannel)
+        MethodChannel(messenger, "kover/volume_key_capture").setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setCapturedKeys" -> {
+                    capturedKeyCodes.clear()
+                    (call.arguments as? List<*>)?.filterIsInstance<Int>()
+                        ?.let(capturedKeyCodes::addAll)
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode in capturedKeyCodes && volumeKeySink != null) {
+            volumeKeySink?.success(keyCode)
+            return true
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+}

--- a/lib/l10n/en.arb
+++ b/lib/l10n/en.arb
@@ -919,5 +919,4 @@
     "@startupLoadingMessage": {
       "description": "Message shown when the app is starting up and loading data"
     }
-
 }

--- a/lib/l10n/en.arb
+++ b/lib/l10n/en.arb
@@ -799,11 +799,15 @@
     "@navigationGestures": {
         "description": "Label for the enable navigation gestures reader option"
     },
-    "keybindNextPage": "Next Page Keybind",
+    "keybinds": "Reader Keybinds",
+    "@keybindsSettings": {
+        "description": "Label for the keybinds settings section"
+    },
+    "keybindNextPage": "Next Page",
     "@keybindNextPage": {
         "description": "Label for the next page keyboard binding setting"
     },
-    "keybindPreviousPage": "Previous Page Keybind",
+    "keybindPreviousPage": "Previous Page",
     "@keybindPreviousPage": {
         "description": "Label for the previous page keyboard binding setting"
     },
@@ -811,7 +815,7 @@
     "@keybindPressAKey": {
         "description": "Placeholder shown while waiting for a key press in the keybind capture dialog"
     },
-    "keybindAlreadyAssigned": "This combination is already assigned to the other action",
+    "keybindAlreadyAssigned": "This combination is already assigned",
     "@keybindAlreadyAssigned": {
         "description": "Error shown when a captured keybind is already used by another action"
     },
@@ -915,4 +919,5 @@
     "@startupLoadingMessage": {
       "description": "Message shown when the app is starting up and loading data"
     }
+
 }

--- a/lib/l10n/en.arb
+++ b/lib/l10n/en.arb
@@ -799,6 +799,30 @@
     "@navigationGestures": {
         "description": "Label for the enable navigation gestures reader option"
     },
+    "keybindNextPage": "Next Page Keybind",
+    "@keybindNextPage": {
+        "description": "Label for the next page keyboard binding setting"
+    },
+    "keybindPreviousPage": "Previous Page Keybind",
+    "@keybindPreviousPage": {
+        "description": "Label for the previous page keyboard binding setting"
+    },
+    "keybindPressAKey": "Press any key…",
+    "@keybindPressAKey": {
+        "description": "Placeholder shown while waiting for a key press in the keybind capture dialog"
+    },
+    "keybindAlreadyAssigned": "This combination is already assigned to the other action",
+    "@keybindAlreadyAssigned": {
+        "description": "Error shown when a captured keybind is already used by another action"
+    },
+    "keybindVolumeUp": "Volume Up",
+    "@keybindVolumeUp": {
+        "description": "Label for the volume up key when shown as a keybinding"
+    },
+    "keybindVolumeDown": "Volume Down",
+    "@keybindVolumeDown": {
+        "description": "Label for the volume down key when shown as a keybinding"
+    },
     "appearance": "Appearance",
     "@appearance": {
       "description": "Label for the appearance settings section"

--- a/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
@@ -5,7 +5,6 @@ import 'package:kover/riverpod/providers/reader/epub_reader.dart';
 import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
 import 'package:kover/utils/cached_image_factory.dart';
 import 'package:kover/utils/layout_constants.dart';
-import 'package:kover/utils/logging.dart';
 import 'package:material_ui/material_ui.dart';
 
 class const EpubHorizontalSubpages({

--- a/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_horizontal_subpages.dart
@@ -5,6 +5,7 @@ import 'package:kover/riverpod/providers/reader/epub_reader.dart';
 import 'package:kover/riverpod/providers/settings/common_reader_settings.dart';
 import 'package:kover/utils/cached_image_factory.dart';
 import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/utils/logging.dart';
 import 'package:material_ui/material_ui.dart';
 
 class const EpubHorizontalSubpages({
@@ -62,31 +63,37 @@ class const EpubHorizontalSubpages({
       navigationProvider.select(
         (state) => state.whenData(
           (data) {
-            if (data.page != page || data.fromObserver) return null;
+            if (data.page != page) return null;
 
-            return spreads ? data.subpage ~/ 2 : data.subpage;
+            return (
+              fromObserver: data.fromObserver,
+              subpage: spreads ? data.subpage ~/ 2 : data.subpage,
+            );
           },
         ),
       ),
       (previous, next) async {
         next.whenData((next) async {
-          final previousSubpage = previous?.value;
-          if (next == null || next == previousSubpage) {
+          final previousSubpage = previous?.value?.subpage;
+          if (next == null ||
+              next.subpage == previousSubpage ||
+              next.fromObserver ||
+              !controller.hasClients ||
+              controller.page?.round() == next.subpage) {
             return;
           }
 
-          if (controller.hasClients && controller.page?.round() != next) {
-            final isSequential =
-                previousSubpage != null && (next - previousSubpage).abs() == 1;
+          final isSequential =
+              previousSubpage != null &&
+              (next.subpage - previousSubpage).abs() == 1;
 
-            isSequential && !data.reduceAnimations
-                ? controller.animateToPage(
-                    next,
-                    duration: LayoutConstants.pageSlideDuration,
-                    curve: Curves.easeInOut,
-                  )
-                : controller.jumpToPage(next);
-          }
+          isSequential && !data.reduceAnimations
+              ? controller.animateToPage(
+                  next.subpage,
+                  duration: LayoutConstants.pageSlideDuration,
+                  curve: Curves.easeInOut,
+                )
+              : controller.jumpToPage(next.subpage);
         });
       },
     );

--- a/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
+++ b/lib/pages/reader/epub_reader/epub_vertical_subpages.dart
@@ -45,23 +45,24 @@ class const EpubVerticalSubpages({
       navigationProvider.select(
         (state) => state.whenData(
           (data) {
-            if (data.page != page || data.fromObserver) return null;
+            if (data.page != page) return null;
 
-            return data.subpage;
+            return (fromObserver: data.fromObserver, subpage: data.subpage);
           },
         ),
       ),
       (previous, next) async {
         next.whenData((next) async {
-          final previousSubpage = previous?.value;
+          final previousSubpage = previous?.value?.subpage;
           if (next == null ||
-              next == previousSubpage ||
+              next.subpage == previousSubpage ||
               !scrollController.hasClients ||
-              count == 0) {
+              count == 0 ||
+              next.fromObserver) {
             return;
           }
 
-          final target = next.clamp(0, count - 1);
+          final target = next.subpage.clamp(0, count - 1);
 
           final isSequential =
               previousSubpage != null && (target - previousSubpage).abs() == 1;

--- a/lib/pages/reader/overlay/reader_overlay.dart
+++ b/lib/pages/reader/overlay/reader_overlay.dart
@@ -1,5 +1,4 @@
 import 'package:material_ui/material_ui.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -9,6 +8,7 @@ import 'package:kover/pages/reader/overlay/overlay_gestures.dart';
 import 'package:kover/pages/reader/overlay/reader_controls.dart';
 import 'package:kover/pages/reader/overlay/reader_header.dart';
 import 'package:kover/pages/reader/overlay/reader_progress.dart';
+import 'package:kover/pages/reader/overlay/reader_shortcuts.dart';
 import 'package:kover/riverpod/providers/reader.dart';
 import 'package:kover/riverpod/providers/reader//reader.dart';
 import 'package:kover/riverpod/providers/reader/reader_navigation.dart';
@@ -22,14 +22,6 @@ enum ShowSnackbar {
   previous,
   next,
   none,
-}
-
-class NextPageIntent extends Intent {
-  const NextPageIntent();
-}
-
-class PreviousPageIntent extends Intent {
-  const PreviousPageIntent();
 }
 
 class ReaderOverlay extends HookConsumerWidget {
@@ -140,25 +132,9 @@ class ReaderOverlay extends HookConsumerWidget {
           return Scaffold(
             endDrawerEnableOpenDragGesture: false,
             endDrawer: endDrawer,
-            body: FocusableActionDetector(
-              autofocus: true,
-              shortcuts: const {
-                SingleActivator(LogicalKeyboardKey.pageDown): NextPageIntent(),
-                SingleActivator(LogicalKeyboardKey.arrowRight):
-                    NextPageIntent(),
-                SingleActivator(LogicalKeyboardKey.pageUp):
-                    PreviousPageIntent(),
-                SingleActivator(LogicalKeyboardKey.arrowLeft):
-                    PreviousPageIntent(),
-              },
-              actions: {
-                NextPageIntent: CallbackAction<NextPageIntent>(
-                  onInvoke: (_) => onNextPage?.call(),
-                ),
-                PreviousPageIntent: CallbackAction<PreviousPageIntent>(
-                  onInvoke: (_) => onPreviousPage?.call(),
-                ),
-              },
+            body: ReaderShortcuts(
+              onNextPage: onNextPage,
+              onPreviousPage: onPreviousPage,
               child: Stack(
                 children: [
                   Positioned.fill(

--- a/lib/pages/reader/overlay/reader_shortcuts.dart
+++ b/lib/pages/reader/overlay/reader_shortcuts.dart
@@ -4,13 +4,9 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
 
-class NextPageIntent extends Intent {
-  const NextPageIntent();
-}
+class const NextPageIntent() extends Intent;
 
-class PreviousPageIntent extends Intent {
-  const PreviousPageIntent();
-}
+class const PreviousPageIntent() extends Intent;
 
 /// Exposes [ShortcutManager.handleKeypress] so synthetic key events (volume
 /// keys captured natively) can use the same dispatch path as hardware keys.
@@ -27,7 +23,7 @@ class ReaderShortcuts extends HookConsumerWidget {
   final void Function()? onPreviousPage;
   final Widget child;
 
-  const ReaderShortcuts({
+  const new({
     super.key,
     this.onNextPage,
     this.onPreviousPage,
@@ -55,22 +51,7 @@ class ReaderShortcuts extends HookConsumerWidget {
       return null;
     }, [shortcuts]);
 
-    // Bound volume keys are captured natively (Android only) and re-injected
-    // into the key event pipeline
-    useEffect(() {
-      final keys = (keyBindings.value?.assigned ?? {})
-          .where((binding) => binding.isVolumeKey)
-          .map((binding) => binding.key)
-          .whereType<LogicalKeyboardKey>()
-          .toSet();
-
-      if (keys.isEmpty) return null;
-
-      setCapturedVolumeKeys(keys);
-      return () => setCapturedVolumeKeys(const {});
-    }, [keyBindings]);
-
-    ref.listen(volumeKeysProvider, (previous, next) {
+    ref.listen(volumeKeysProvider(), (previous, next) {
       next.whenData((event) {
         manager.injectKeyEvent(context, event.toKeyDownEvent());
       });

--- a/lib/pages/reader/overlay/reader_shortcuts.dart
+++ b/lib/pages/reader/overlay/reader_shortcuts.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';

--- a/lib/pages/reader/overlay/reader_shortcuts.dart
+++ b/lib/pages/reader/overlay/reader_shortcuts.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+
+class NextPageIntent extends Intent {
+  const NextPageIntent();
+}
+
+class PreviousPageIntent extends Intent {
+  const PreviousPageIntent();
+}
+
+/// Exposes [ShortcutManager.handleKeypress] so synthetic key events (volume
+/// keys captured natively) can use the same dispatch path as hardware keys.
+final class _ReaderShortcutManager({super.shortcuts}) extends ShortcutManager {
+  KeyEventResult injectKeyEvent(BuildContext context, KeyEvent event) {
+    return handleKeypress(context, event);
+  }
+}
+
+/// Handles the reader's keyboard shortcuts and natively captured volume keys
+/// through a single [ShortcutManager].
+class ReaderShortcuts extends HookConsumerWidget {
+  final void Function()? onNextPage;
+  final void Function()? onPreviousPage;
+  final Widget child;
+
+  const ReaderShortcuts({
+    super.key,
+    this.onNextPage,
+    this.onPreviousPage,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final keyBindings = ref.watch(keybindsSettingsProvider);
+
+    final nextPageIntent = const NextPageIntent();
+    final previousPageIntent = const PreviousPageIntent();
+
+    final shortcuts = <ShortcutActivator, Intent>{
+      ?keyBindings.value?.nextPage.activator: nextPageIntent,
+      ?keyBindings.value?.previousPage.activator: previousPageIntent,
+    };
+
+    final manager = useMemoized(
+      () => _ReaderShortcutManager(shortcuts: shortcuts),
+    );
+
+    useEffect(() {
+      manager.shortcuts = shortcuts;
+      return null;
+    }, [shortcuts]);
+
+    // Bound volume keys are captured natively (Android only) and re-injected
+    // into the key event pipeline
+    useEffect(() {
+      final keys = (keyBindings.value?.assigned ?? {})
+          .where((binding) => binding.isVolumeKey)
+          .map((binding) => binding.key)
+          .whereType<LogicalKeyboardKey>()
+          .toSet();
+
+      if (keys.isEmpty) return null;
+
+      setCapturedVolumeKeys(keys);
+      return () => setCapturedVolumeKeys(const {});
+    }, [keyBindings]);
+
+    ref.listen(volumeKeysProvider, (previous, next) {
+      next.whenData((event) {
+        manager.injectKeyEvent(context, event.toKeyDownEvent());
+      });
+    });
+
+    return Shortcuts.manager(
+      manager: manager,
+      child: Actions(
+        actions: {
+          NextPageIntent: CallbackAction<NextPageIntent>(
+            onInvoke: (intent) => onNextPage?.call(),
+          ),
+          PreviousPageIntent: CallbackAction<PreviousPageIntent>(
+            onInvoke: (intent) => onPreviousPage?.call(),
+          ),
+        },
+        child: Focus(autofocus: true, child: child),
+      ),
+    );
+  }
+}

--- a/lib/pages/reader/overlay/reader_shortcuts.dart
+++ b/lib/pages/reader/overlay/reader_shortcuts.dart
@@ -31,18 +31,27 @@ class ReaderShortcuts extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final keyBindings = ref.watch(keybindsSettingsProvider);
+    final value = ref.watch(keybindsSettingsProvider).value;
 
     final nextPageIntent = const NextPageIntent();
     final previousPageIntent = const PreviousPageIntent();
 
-    final shortcuts = <ShortcutActivator, Intent>{
-      ?keyBindings.value?.nextPage.activator: nextPageIntent,
-      ?keyBindings.value?.previousPage.activator: previousPageIntent,
-    };
+    final shortcuts = useMemoized(
+      () => <ShortcutActivator, Intent>{
+        ?value?.nextPage.activator: nextPageIntent,
+        ?value?.previousPage.activator: previousPageIntent,
+      },
+      [value],
+    );
 
     final manager = useMemoized(
       () => _ReaderShortcutManager(shortcuts: shortcuts),
+    );
+
+    useEffect(
+      () =>
+          () => manager.dispose(),
+      [manager],
     );
 
     useEffect(() {

--- a/lib/pages/settings/general_settings.dart
+++ b/lib/pages/settings/general_settings.dart
@@ -1,5 +1,3 @@
-import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
-import 'package:material_ui/material_ui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:kover/generated/l10n/app_localizations.dart';
@@ -9,10 +7,10 @@ import 'package:kover/riverpod/providers/settings/general_settings.dart';
 import 'package:kover/utils/constants/kover_icons.dart';
 import 'package:kover/utils/layout_constants.dart';
 import 'package:kover/widgets/settings/boolean_option.dart';
-import 'package:kover/widgets/settings/keybind_option.dart';
 import 'package:kover/widgets/settings/navigate_option.dart';
 import 'package:kover/widgets/settings/select_option.dart';
 import 'package:kover/widgets/util/async_value.dart';
+import 'package:material_ui/material_ui.dart';
 
 class GeneralSettings extends ConsumerWidget {
   const GeneralSettings({super.key});
@@ -35,7 +33,6 @@ class GeneralSettings extends ConsumerWidget {
               style: Theme.of(context).textTheme.headlineSmall,
             ),
             const _Locale(),
-            const _Keybinds(),
             const NavbarEditor(),
             const _SendDiagnostics(),
             const _LocalLogs(),
@@ -91,47 +88,6 @@ class _Locale extends ConsumerWidget {
           onChanged: (value) {
             ref.read(generalSettingsProvider.notifier).setLocale(value);
           },
-        );
-      },
-    );
-  }
-}
-
-class _Keybinds extends ConsumerWidget {
-  const _Keybinds();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l = AppLocalizations.of(context);
-    final keybindsSettings = ref.watch(keybindsSettingsProvider);
-
-    return Async(
-      asyncValue: keybindsSettings,
-      data: (data) {
-        return Column(
-          mainAxisSize: .min,
-          crossAxisAlignment: .start,
-          spacing: LayoutConstants.largePadding,
-          children: [
-            KeybindOption(
-              title: l.keybindNextPage,
-              icon: KoverIcons.readingDirectionLTR,
-              value: data.nextPage,
-              defaultValue: KeybindsSettingsState.defaultNextPage,
-              onChanged: (value) => ref
-                  .read(keybindsSettingsProvider.notifier)
-                  .setNextPageKey(value),
-            ),
-            KeybindOption(
-              title: l.keybindPreviousPage,
-              icon: KoverIcons.readingDirectionRTL,
-              value: data.previousPage,
-              defaultValue: KeybindsSettingsState.defaultPreviousPage,
-              onChanged: (value) => ref
-                  .read(keybindsSettingsProvider.notifier)
-                  .setPreviousPageKey(value),
-            ),
-          ],
         );
       },
     );

--- a/lib/pages/settings/general_settings.dart
+++ b/lib/pages/settings/general_settings.dart
@@ -1,3 +1,4 @@
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -8,6 +9,7 @@ import 'package:kover/riverpod/providers/settings/general_settings.dart';
 import 'package:kover/utils/constants/kover_icons.dart';
 import 'package:kover/utils/layout_constants.dart';
 import 'package:kover/widgets/settings/boolean_option.dart';
+import 'package:kover/widgets/settings/keybind_option.dart';
 import 'package:kover/widgets/settings/navigate_option.dart';
 import 'package:kover/widgets/settings/select_option.dart';
 import 'package:kover/widgets/util/async_value.dart';
@@ -33,6 +35,7 @@ class GeneralSettings extends ConsumerWidget {
               style: Theme.of(context).textTheme.headlineSmall,
             ),
             const _Locale(),
+            const _Keybinds(),
             const NavbarEditor(),
             const _SendDiagnostics(),
             const _LocalLogs(),
@@ -88,6 +91,47 @@ class _Locale extends ConsumerWidget {
           onChanged: (value) {
             ref.read(generalSettingsProvider.notifier).setLocale(value);
           },
+        );
+      },
+    );
+  }
+}
+
+class _Keybinds extends ConsumerWidget {
+  const _Keybinds();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final keybindsSettings = ref.watch(keybindsSettingsProvider);
+
+    return Async(
+      asyncValue: keybindsSettings,
+      data: (data) {
+        return Column(
+          mainAxisSize: .min,
+          crossAxisAlignment: .start,
+          spacing: LayoutConstants.largePadding,
+          children: [
+            KeybindOption(
+              title: l.keybindNextPage,
+              icon: KoverIcons.readingDirectionLTR,
+              value: data.nextPage,
+              defaultValue: KeybindsSettingsState.defaultNextPage,
+              onChanged: (value) => ref
+                  .read(keybindsSettingsProvider.notifier)
+                  .setNextPageKey(value),
+            ),
+            KeybindOption(
+              title: l.keybindPreviousPage,
+              icon: KoverIcons.readingDirectionRTL,
+              value: data.previousPage,
+              defaultValue: KeybindsSettingsState.defaultPreviousPage,
+              onChanged: (value) => ref
+                  .read(keybindsSettingsProvider.notifier)
+                  .setPreviousPageKey(value),
+            ),
+          ],
         );
       },
     );

--- a/lib/pages/settings/keybinds_settings.dart
+++ b/lib/pages/settings/keybinds_settings.dart
@@ -20,7 +20,7 @@ class KeybindsSettings extends ConsumerWidget {
         padding: LayoutConstants.mediumEdgeInsets,
         child: Column(
           mainAxisSize: .min,
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: .start,
           spacing: LayoutConstants.largePadding,
           children: [
             Text(

--- a/lib/pages/settings/keybinds_settings.dart
+++ b/lib/pages/settings/keybinds_settings.dart
@@ -1,0 +1,77 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/generated/l10n/app_localizations.dart';
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+import 'package:kover/utils/constants/kover_icons.dart';
+import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/widgets/settings/keybind_option.dart';
+import 'package:kover/widgets/util/async_value.dart';
+import 'package:material_ui/material_ui.dart';
+
+class KeybindsSettings extends ConsumerWidget {
+  const new({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+
+    return Card(
+      margin: .zero,
+      child: Padding(
+        padding: LayoutConstants.mediumEdgeInsets,
+        child: Column(
+          mainAxisSize: .min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: LayoutConstants.largePadding,
+          children: [
+            Text(
+              l.keybinds,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const _Keybinds(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Keybinds extends ConsumerWidget {
+  const new();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final keybindsSettings = ref.watch(keybindsSettingsProvider);
+
+    return Async(
+      asyncValue: keybindsSettings,
+      data: (data) {
+        return Column(
+          mainAxisSize: .min,
+          crossAxisAlignment: .start,
+          spacing: LayoutConstants.largePadding,
+          children: [
+            KeybindOption(
+              title: l.keybindNextPage,
+              icon: KoverIcons.readingDirectionLTR,
+              value: data.nextPage,
+              defaultValue: KeybindsSettingsState.defaultNextPage,
+              onChanged: (value) => ref
+                  .read(keybindsSettingsProvider.notifier)
+                  .setNextPageKey(value),
+            ),
+            KeybindOption(
+              title: l.keybindPreviousPage,
+              icon: KoverIcons.readingDirectionRTL,
+              value: data.previousPage,
+              defaultValue: KeybindsSettingsState.defaultPreviousPage,
+              onChanged: (value) => ref
+                  .read(keybindsSettingsProvider.notifier)
+                  .setPreviousPageKey(value),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:kover/pages/settings/appearance_settings.dart';
 import 'package:kover/pages/settings/credentials_settings.dart';
 import 'package:kover/pages/settings/data_management_settings.dart';
 import 'package:kover/pages/settings/general_settings.dart';
+import 'package:kover/pages/settings/keybinds_settings.dart';
 import 'package:kover/pages/settings/version_label.dart';
 import 'package:kover/utils/layout_constants.dart';
 import 'package:kover/widgets/util/sliver_adaptive_padding.dart';
@@ -36,6 +37,7 @@ class SettingsPage extends ConsumerWidget {
                     CredentialsSettings(),
                     GeneralSettings(),
                     AppearanceSettings(),
+                    KeybindsSettings(),
                     DataManagementSettings(),
                     VersionLabel(),
                   ],

--- a/lib/riverpod/providers/platform.dart
+++ b/lib/riverpod/providers/platform.dart
@@ -1,0 +1,25 @@
+import 'package:kover/utils/safe_platform.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'platform.g.dart';
+
+enum AppPlatform {
+  android,
+  iOS,
+  windows,
+  macOS,
+  linux,
+  web,
+  unknown,
+}
+
+@riverpod
+AppPlatform appPlatform(Ref ref) {
+  if (SafePlatform.isWeb) return .web;
+  if (SafePlatform.isAndroid) return .android;
+  if (SafePlatform.isIOS) return .iOS;
+  if (SafePlatform.isWindows) return .windows;
+  if (SafePlatform.isMacOS) return .macOS;
+  if (SafePlatform.isLinux) return .linux;
+  return .unknown;
+}

--- a/lib/riverpod/providers/settings/keybinds_settings.dart
+++ b/lib/riverpod/providers/settings/keybinds_settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/experimental/persist.dart';
 import 'package:kover/riverpod/repository/storage_repository.dart';
+import 'package:kover/utils/constants/platform_channels.dart';
 import 'package:kover/utils/logging.dart';
 import 'package:riverpod_annotation/experimental/json_persist.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -124,7 +125,7 @@ final capturableVolumeKeys = {
   LogicalKeyboardKey.audioVolumeDown,
 };
 
-const _captureChannel = MethodChannel('kover/volume_key_capture');
+const _captureChannel = PlatformChannels.volumeKeyCapture;
 
 int? _volumeKeyCodeFor(LogicalKeyboardKey key) => switch (key) {
   .audioVolumeUp => volumeUpKeyCode,
@@ -146,7 +147,7 @@ LogicalKeyboardKey? _logicalKeyForVolumeKeyCode(int keyCode) =>
 Future<void> _setCapturedVolumeKeys(Set<LogicalKeyboardKey> keys) async {
   try {
     await _captureChannel.invokeMethod<void>(
-      'setCapturedKeys',
+      PlatformChannels.volumeKeyCaptureSetCapturedKeysMethod,
       keys.map(_volumeKeyCodeFor).nonNulls.toList(),
     );
   } on MissingPluginException {
@@ -190,7 +191,7 @@ Stream<VolumeKeyEvent> volumeKeys(
 
   final controller = StreamController<VolumeKeyEvent>();
 
-  final subscription = const EventChannel('kover/volume_keys')
+  final subscription = PlatformChannels.volumeKeys
       .receiveBroadcastStream()
       .listen(
         (data) {

--- a/lib/riverpod/providers/settings/keybinds_settings.dart
+++ b/lib/riverpod/providers/settings/keybinds_settings.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hooks_riverpod/experimental/persist.dart';
+import 'package:kover/riverpod/repository/storage_repository.dart';
+import 'package:kover/utils/logging.dart';
+import 'package:riverpod_annotation/experimental/json_persist.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'keybinds_settings.freezed.dart';
+part 'keybinds_settings.g.dart';
+
+@freezed
+sealed class ReaderKeyBinding with _$ReaderKeyBinding {
+  const ReaderKeyBinding._();
+
+  const factory ReaderKeyBinding({
+    required int id,
+    required String keyLabel,
+    @Default(false) bool control,
+    @Default(false) bool alt,
+    @Default(false) bool shift,
+    @Default(false) bool meta,
+  }) = _ReaderKeyBinding;
+
+  factory ReaderKeyBinding.fromJson(Map<String, Object?> json) =>
+      _$ReaderKeyBindingFromJson(json);
+
+  LogicalKeyboardKey? get key => LogicalKeyboardKey.findKeyByKeyId(id);
+
+  bool get isVolumeKey =>
+      id == LogicalKeyboardKey.audioVolumeUp.keyId ||
+      id == LogicalKeyboardKey.audioVolumeDown.keyId;
+
+  SingleActivator? get activator {
+    final logicalKey = key;
+
+    if (logicalKey == null) return null;
+
+    return SingleActivator(
+      logicalKey,
+      control: control,
+      alt: alt,
+      shift: shift,
+      meta: meta,
+    );
+  }
+
+  String get label => [
+    if (control) 'Ctrl',
+    if (alt) 'Alt',
+    if (shift) 'Shift',
+    if (meta) 'Super',
+    keyLabel,
+  ].join(' + ');
+}
+
+@freezed
+sealed class KeybindsSettingsState with _$KeybindsSettingsState {
+  const KeybindsSettingsState._();
+
+  const factory KeybindsSettingsState({
+    ReaderKeyBinding? nextPageKey,
+    ReaderKeyBinding? previousPageKey,
+  }) = _KeybindsSettingsState;
+
+  factory fromJson(Map<String, dynamic> json) =>
+      _$KeybindsSettingsStateFromJson(json);
+
+  static ReaderKeyBinding get defaultNextPage => ReaderKeyBinding(
+    id: LogicalKeyboardKey.arrowRight.keyId,
+    keyLabel: LogicalKeyboardKey.arrowRight.keyLabel,
+  );
+
+  static ReaderKeyBinding get defaultPreviousPage => ReaderKeyBinding(
+    id: LogicalKeyboardKey.arrowLeft.keyId,
+    keyLabel: LogicalKeyboardKey.arrowLeft.keyLabel,
+  );
+
+  ReaderKeyBinding get nextPage => nextPageKey ?? defaultNextPage;
+
+  ReaderKeyBinding get previousPage => previousPageKey ?? defaultPreviousPage;
+
+  Set<ReaderKeyBinding> get assigned => {nextPage, previousPage};
+}
+
+@riverpod
+@JsonPersist()
+class KeybindsSettings extends _$KeybindsSettings {
+  @override
+  Future<KeybindsSettingsState> build() async {
+    await persist(
+      ref.watch(storageProvider.future),
+      options: const StorageOptions(cacheTime: StorageCacheTime.unsafe_forever),
+    ).future;
+
+    return state.value ?? const KeybindsSettingsState();
+  }
+
+  Future<void> setNextPageKey(ReaderKeyBinding value) async {
+    final current = await future;
+    state = .data(current.copyWith(nextPageKey: value));
+    log.info('set next page keybind', attributes: {'value': value.label});
+  }
+
+  Future<void> setPreviousPageKey(ReaderKeyBinding value) async {
+    final current = await future;
+    state = .data(current.copyWith(previousPageKey: value));
+    log.info('set previous page keybind', attributes: {'value': value.label});
+  }
+}
+
+/// Android keycodes for the volume keys.
+const volumeUpKeyCode = 24;
+const volumeDownKeyCode = 25;
+
+/// All volume keys that can be captured and bound.
+final capturableVolumeKeys = {
+  LogicalKeyboardKey.audioVolumeUp,
+  LogicalKeyboardKey.audioVolumeDown,
+};
+
+const _captureChannel = MethodChannel('kover/volume_key_capture');
+
+int? volumeKeyCodeFor(LogicalKeyboardKey key) => switch (key) {
+  .audioVolumeUp => volumeUpKeyCode,
+  .audioVolumeDown => volumeDownKeyCode,
+  _ => null,
+};
+
+LogicalKeyboardKey? logicalKeyForVolumeKeyCode(int keyCode) =>
+    switch (keyCode) {
+      volumeUpKeyCode => .audioVolumeUp,
+      volumeDownKeyCode => .audioVolumeDown,
+      _ => null,
+    };
+
+/// Sets which volume keys the platform should capture and emit through
+/// [volumeKeysProvider] instead of letting the system handle them.
+///
+/// Only supported on Android; a no-op on other platforms.
+Future<void> setCapturedVolumeKeys(Set<LogicalKeyboardKey> keys) async {
+  try {
+    await _captureChannel.invokeMethod<void>(
+      'setCapturedKeys',
+      keys.map(volumeKeyCodeFor).nonNulls.toList(),
+    );
+  } on MissingPluginException {
+    // Volume key capture is only implemented on Android.
+  }
+}
+
+/// A single volume key press.
+final class const VolumeKeyEvent(final LogicalKeyboardKey key) {
+  /// A synthetic [KeyDownEvent] for dispatching through a [ShortcutManager].
+  KeyDownEvent toKeyDownEvent() => KeyDownEvent(
+    physicalKey: switch (key) {
+      .audioVolumeUp => PhysicalKeyboardKey.audioVolumeUp,
+      _ => PhysicalKeyboardKey.audioVolumeDown,
+    },
+    logicalKey: key,
+    timeStamp: Duration.zero,
+    synthesized: true,
+  );
+}
+
+@riverpod
+Stream<VolumeKeyEvent> volumeKeys(Ref ref) {
+  final controller = StreamController<VolumeKeyEvent>();
+
+  final subscription = const EventChannel('kover/volume_keys')
+      .receiveBroadcastStream()
+      .listen(
+        (data) {
+          if (data case final int keyCode) {
+            final key = logicalKeyForVolumeKeyCode(keyCode);
+            if (key != null) controller.add(VolumeKeyEvent(key));
+          }
+        },
+        onError: (Object error) {},
+      );
+
+  ref.onDispose(() {
+    subscription.cancel();
+    controller.close();
+  });
+
+  return controller.stream;
+}

--- a/lib/riverpod/providers/settings/keybinds_settings.dart
+++ b/lib/riverpod/providers/settings/keybinds_settings.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/experimental/persist.dart';
+import 'package:kover/riverpod/providers/platform.dart';
 import 'package:kover/riverpod/repository/storage_repository.dart';
 import 'package:kover/utils/constants/platform_channels.dart';
 import 'package:kover/utils/logging.dart';
@@ -174,6 +175,11 @@ Stream<VolumeKeyEvent> volumeKeys(
   Ref ref, {
   Set<LogicalKeyboardKey>? capturedKeys,
 }) {
+  // Volume key capture is only implemented on Android.
+  if (ref.watch(appPlatformProvider) != .android) {
+    return const Stream<VolumeKeyEvent>.empty();
+  }
+
   final keybindsSettings = ref.watch(keybindsSettingsProvider);
   final keys =
       capturedKeys ??

--- a/lib/riverpod/providers/settings/keybinds_settings.dart
+++ b/lib/riverpod/providers/settings/keybinds_settings.dart
@@ -113,7 +113,9 @@ class KeybindsSettings extends _$KeybindsSettings {
 }
 
 /// Android keycodes for the volume keys.
+@visibleForTesting
 const volumeUpKeyCode = 24;
+@visibleForTesting
 const volumeDownKeyCode = 25;
 
 /// All volume keys that can be captured and bound.
@@ -124,13 +126,13 @@ final capturableVolumeKeys = {
 
 const _captureChannel = MethodChannel('kover/volume_key_capture');
 
-int? volumeKeyCodeFor(LogicalKeyboardKey key) => switch (key) {
+int? _volumeKeyCodeFor(LogicalKeyboardKey key) => switch (key) {
   .audioVolumeUp => volumeUpKeyCode,
   .audioVolumeDown => volumeDownKeyCode,
   _ => null,
 };
 
-LogicalKeyboardKey? logicalKeyForVolumeKeyCode(int keyCode) =>
+LogicalKeyboardKey? _logicalKeyForVolumeKeyCode(int keyCode) =>
     switch (keyCode) {
       volumeUpKeyCode => .audioVolumeUp,
       volumeDownKeyCode => .audioVolumeDown,
@@ -141,11 +143,11 @@ LogicalKeyboardKey? logicalKeyForVolumeKeyCode(int keyCode) =>
 /// [volumeKeysProvider] instead of letting the system handle them.
 ///
 /// Only supported on Android; a no-op on other platforms.
-Future<void> setCapturedVolumeKeys(Set<LogicalKeyboardKey> keys) async {
+Future<void> _setCapturedVolumeKeys(Set<LogicalKeyboardKey> keys) async {
   try {
     await _captureChannel.invokeMethod<void>(
       'setCapturedKeys',
-      keys.map(volumeKeyCodeFor).nonNulls.toList(),
+      keys.map(_volumeKeyCodeFor).nonNulls.toList(),
     );
   } on MissingPluginException {
     // Volume key capture is only implemented on Android.
@@ -167,7 +169,25 @@ final class const VolumeKeyEvent(final LogicalKeyboardKey key) {
 }
 
 @riverpod
-Stream<VolumeKeyEvent> volumeKeys(Ref ref) {
+Stream<VolumeKeyEvent> volumeKeys(
+  Ref ref, {
+  Set<LogicalKeyboardKey>? capturedKeys,
+}) {
+  final keybindsSettings = ref.watch(keybindsSettingsProvider);
+  final keys =
+      capturedKeys ??
+      (keybindsSettings.value?.assigned ?? {})
+          .where((binding) => binding.isVolumeKey)
+          .map((binding) => binding.key)
+          .whereType<LogicalKeyboardKey>()
+          .toSet();
+
+  _setCapturedVolumeKeys(keys);
+
+  ref.onDispose(() {
+    _setCapturedVolumeKeys(const {});
+  });
+
   final controller = StreamController<VolumeKeyEvent>();
 
   final subscription = const EventChannel('kover/volume_keys')
@@ -175,7 +195,7 @@ Stream<VolumeKeyEvent> volumeKeys(Ref ref) {
       .listen(
         (data) {
           if (data case final int keyCode) {
-            final key = logicalKeyForVolumeKeyCode(keyCode);
+            final key = _logicalKeyForVolumeKeyCode(keyCode);
             if (key != null) controller.add(VolumeKeyEvent(key));
           }
         },

--- a/lib/utils/constants/kover_icons.dart
+++ b/lib/utils/constants/kover_icons.dart
@@ -83,4 +83,5 @@ sealed class KoverIcons {
   static const IconData collapsePanel = LucideIcons.panelLeftClose;
   static const IconData carousel = LucideIcons.galleryHorizontalEnd;
   static const IconData grid = LucideIcons.layoutGrid;
+  static const IconData keyboard = LucideIcons.keyboard;
 }

--- a/lib/utils/constants/platform_channels.dart
+++ b/lib/utils/constants/platform_channels.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/services.dart';
+
+sealed class PlatformChannels {
+  /// Stream of volume key events captured natively on Android.
+  static const volumeKeys = EventChannel('kover/volume_keys');
+
+  /// Method channel for setting which volume keys should be captured natively on Android.
+  static const volumeKeyCapture = MethodChannel('kover/volume_key_capture');
+
+  /// Method name for setting which volume keys should be captured natively on Android.
+  static const volumeKeyCaptureSetCapturedKeysMethod = 'setCapturedKeys';
+}

--- a/lib/utils/logging.dart
+++ b/lib/utils/logging.dart
@@ -133,7 +133,7 @@ class KoverLogger {
         level: level,
         message: scrubLooseUrls(message.toString()),
         attributes: attributes.map(
-          (key, value) => MapEntry(key, value.toString()),
+          (key, value) => MapEntry(key, scrubLooseUrls(value.toString())),
         ),
         error: error != null ? scrubLooseUrls(error.toString()) : null,
       ),

--- a/lib/widgets/settings/keybind_option.dart
+++ b/lib/widgets/settings/keybind_option.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/services.dart';
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+import 'package:kover/utils/logging.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/generated/l10n/app_localizations.dart';
+import 'package:kover/utils/constants/kover_icons.dart';
+import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/widgets/settings/option_container.dart';
+
+class KeybindOption extends ConsumerWidget {
+  final String title;
+  final IconData? icon;
+  final ReaderKeyBinding value;
+  final ReaderKeyBinding defaultValue;
+  final void Function(ReaderKeyBinding value)? onChanged;
+
+  const KeybindOption({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.defaultValue,
+    this.icon,
+    this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return OptionContainer(
+      title: title,
+      icon: icon,
+      sameRow: true,
+      child: OutlinedButton.icon(
+        icon: const Icon(KoverIcons.keyboard),
+        label: _KeyBindingLabel(binding: value),
+        onPressed: () async {
+          final result = await showDialog<ReaderKeyBinding>(
+            context: context,
+            builder: (context) => _KeybindCaptureDialog(
+              title: title,
+              currentValue: value,
+              defaultValue: defaultValue,
+            ),
+          );
+
+          if (result != null) {
+            onChanged?.call(result);
+          }
+        },
+      ),
+    );
+  }
+}
+
+class _KeyBindingLabel extends StatelessWidget {
+  final ReaderKeyBinding binding;
+  final TextStyle? style;
+
+  const _KeyBindingLabel({required this.binding, this.style});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final materialL = MaterialLocalizations.of(context);
+
+    final keyLabel = switch (binding.key) {
+      LogicalKeyboardKey.audioVolumeUp => l.keybindVolumeUp,
+      LogicalKeyboardKey.audioVolumeDown => l.keybindVolumeDown,
+      LogicalKeyboardKey.arrowLeft => '←',
+      LogicalKeyboardKey.arrowRight => '→',
+      LogicalKeyboardKey.arrowUp => '↑',
+      LogicalKeyboardKey.arrowDown => '↓',
+      _ => binding.keyLabel,
+    };
+
+    return Text(
+      [
+        if (binding.control) materialL.keyboardKeyControl,
+        if (binding.alt) materialL.keyboardKeyAlt,
+        if (binding.shift) materialL.keyboardKeyShift,
+        if (binding.meta) materialL.keyboardKeyMeta,
+        keyLabel,
+      ].join(' + '),
+      style: style,
+    );
+  }
+}
+
+class _KeybindCaptureDialog extends HookConsumerWidget {
+  static final _controlKeys = {
+    LogicalKeyboardKey.controlLeft,
+    LogicalKeyboardKey.controlRight,
+  };
+  static final _altKeys = {
+    LogicalKeyboardKey.altLeft,
+    LogicalKeyboardKey.altRight,
+  };
+  static final _shiftKeys = {
+    LogicalKeyboardKey.shiftLeft,
+    LogicalKeyboardKey.shiftRight,
+  };
+  static final _metaKeys = {
+    LogicalKeyboardKey.metaLeft,
+    LogicalKeyboardKey.metaRight,
+  };
+  static final _modifierKeys = {
+    ..._controlKeys,
+    ..._altKeys,
+    ..._shiftKeys,
+    ..._metaKeys,
+  };
+
+  final String title;
+  final ReaderKeyBinding currentValue;
+  final ReaderKeyBinding defaultValue;
+
+  const _KeybindCaptureDialog({
+    required this.title,
+    required this.currentValue,
+    required this.defaultValue,
+  });
+
+  static bool _anyPressed(Set pressed, Set keys) => keys.any(pressed.contains);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final captured = useState<ReaderKeyBinding?>(null);
+    final pending = captured.value;
+
+    // Capture both volume keys natively (Android only) while the dialog is
+    // open so either can be bound; released when closed.
+    useEffect(() {
+      setCapturedVolumeKeys(capturableVolumeKeys);
+      return () => setCapturedVolumeKeys(const {});
+    }, []);
+
+    // Volume keys arrive via the volume key stream instead of the focus
+    // system.
+    ref.listen(volumeKeysProvider, (previous, next) {
+      next.whenData((event) {
+        captured.value = ReaderKeyBinding(
+          id: event.key.keyId,
+          keyLabel: event.key.keyLabel,
+        );
+      });
+    });
+
+    final assigned =
+        ref.watch(keybindsSettingsProvider).value?.assigned ??
+        const <ReaderKeyBinding>{};
+
+    final conflicts =
+        pending != null &&
+        assigned.any(
+          (binding) => binding != currentValue && binding == pending,
+        );
+
+    return AlertDialog(
+      title: Text(title),
+      content: Column(
+        mainAxisSize: .min,
+        crossAxisAlignment: .start,
+        spacing: LayoutConstants.smallPadding,
+        children: [
+          Focus(
+            autofocus: true,
+            onKeyEvent: (node, event) {
+              if (event is! KeyDownEvent) return .ignored;
+              if (event.logicalKey == LogicalKeyboardKey.escape) {
+                return .ignored;
+              }
+              if (_modifierKeys.contains(event.logicalKey)) return .handled;
+
+              log.debug(
+                'Keybind capture',
+                attributes: {'key': event.logicalKey},
+              );
+
+              final pressed = HardwareKeyboard.instance.logicalKeysPressed;
+              captured.value = ReaderKeyBinding(
+                id: event.logicalKey.keyId,
+                keyLabel: event.logicalKey.keyLabel,
+                control: _anyPressed(pressed, _controlKeys),
+                alt: _anyPressed(pressed, _altKeys),
+                shift: _anyPressed(pressed, _shiftKeys),
+                meta: _anyPressed(pressed, _metaKeys),
+              );
+
+              return .handled;
+            },
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(
+                horizontal: LayoutConstants.mediumPadding,
+                vertical: LayoutConstants.smallPadding + 4.0,
+              ),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+                borderRadius: BorderRadius.circular(
+                  LayoutConstants.smallerBorderRadius,
+                ),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: pending == null
+                        ? Text(
+                            l.keybindPressAKey,
+                            style: Theme.of(context).textTheme.bodyLarge
+                                ?.copyWith(color: Theme.of(context).hintColor),
+                          )
+                        : _KeyBindingLabel(
+                            binding: pending,
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                  ),
+                  const Icon(KoverIcons.keyboard),
+                ],
+              ),
+            ),
+          ),
+          if (conflicts)
+            Text(
+              l.keybindAlreadyAssigned,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.cancel),
+        ),
+        TextButton.icon(
+          onPressed: () => Navigator.of(context).pop(defaultValue),
+          icon: const Icon(KoverIcons.reset),
+          label: Text(l.reset),
+        ),
+        FilledButton(
+          onPressed: pending == null || conflicts
+              ? null
+              : () => Navigator.of(context).pop(pending),
+          child: Text(l.save),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/settings/keybind_option.dart
+++ b/lib/widgets/settings/keybind_option.dart
@@ -129,16 +129,10 @@ class _KeybindCaptureDialog extends HookConsumerWidget {
     final captured = useState<ReaderKeyBinding?>(null);
     final pending = captured.value;
 
-    // Capture both volume keys natively (Android only) while the dialog is
-    // open so either can be bound; released when closed.
-    useEffect(() {
-      setCapturedVolumeKeys(capturableVolumeKeys);
-      return () => setCapturedVolumeKeys(const {});
-    }, []);
-
-    // Volume keys arrive via the volume key stream instead of the focus
-    // system.
-    ref.listen(volumeKeysProvider, (previous, next) {
+    ref.listen(volumeKeysProvider(capturedKeys: capturableVolumeKeys), (
+      previous,
+      next,
+    ) {
       next.whenData((event) {
         captured.value = ReaderKeyBinding(
           id: event.key.keyId,

--- a/lib/widgets/settings/keybind_option.dart
+++ b/lib/widgets/settings/keybind_option.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/services.dart';
-import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
-import 'package:kover/utils/logging.dart';
-import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/generated/l10n/app_localizations.dart';
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
 import 'package:kover/utils/constants/kover_icons.dart';
 import 'package:kover/utils/layout_constants.dart';
+import 'package:kover/utils/logging.dart';
 import 'package:kover/widgets/settings/option_container.dart';
+import 'package:material_ui/material_ui.dart';
 
 class KeybindOption extends ConsumerWidget {
   final String title;
@@ -55,9 +55,8 @@ class KeybindOption extends ConsumerWidget {
 
 class _KeyBindingLabel extends StatelessWidget {
   final ReaderKeyBinding binding;
-  final TextStyle? style;
 
-  const new({required this.binding, this.style});
+  const new({required this.binding});
 
   @override
   Widget build(BuildContext context) {
@@ -82,7 +81,6 @@ class _KeyBindingLabel extends StatelessWidget {
         if (binding.meta) materialL.keyboardKeyMeta,
         keyLabel,
       ].join(' + '),
-      style: style,
     );
   }
 }
@@ -125,6 +123,7 @@ class _KeybindCaptureDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final captured = useState<ReaderKeyBinding?>(null);
     final pending = captured.value;
@@ -186,13 +185,13 @@ class _KeybindCaptureDialog extends HookConsumerWidget {
             },
             child: Container(
               width: double.infinity,
-              padding: const EdgeInsets.symmetric(
+              padding: const .symmetric(
                 horizontal: LayoutConstants.mediumPadding,
-                vertical: LayoutConstants.smallPadding + 4.0,
+                vertical: LayoutConstants.smallPadding,
               ),
               decoration: BoxDecoration(
-                border: Border.all(
-                  color: Theme.of(context).colorScheme.outline,
+                border: .all(
+                  color: theme.colorScheme.outline,
                 ),
                 borderRadius: BorderRadius.circular(
                   LayoutConstants.smallerBorderRadius,
@@ -204,12 +203,12 @@ class _KeybindCaptureDialog extends HookConsumerWidget {
                     child: pending == null
                         ? Text(
                             l.keybindPressAKey,
-                            style: Theme.of(context).textTheme.bodyLarge
-                                ?.copyWith(color: Theme.of(context).hintColor),
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.hintColor,
+                            ),
                           )
                         : _KeyBindingLabel(
                             binding: pending,
-                            style: Theme.of(context).textTheme.bodyLarge,
                           ),
                   ),
                   const Icon(KoverIcons.keyboard),
@@ -220,8 +219,8 @@ class _KeybindCaptureDialog extends HookConsumerWidget {
           if (conflicts)
             Text(
               l.keybindAlreadyAssigned,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.error,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
               ),
             ),
         ],

--- a/lib/widgets/settings/keybind_option.dart
+++ b/lib/widgets/settings/keybind_option.dart
@@ -16,7 +16,7 @@ class KeybindOption extends ConsumerWidget {
   final ReaderKeyBinding defaultValue;
   final void Function(ReaderKeyBinding value)? onChanged;
 
-  const KeybindOption({
+  const new({
     super.key,
     required this.title,
     required this.value,
@@ -57,7 +57,7 @@ class _KeyBindingLabel extends StatelessWidget {
   final ReaderKeyBinding binding;
   final TextStyle? style;
 
-  const _KeyBindingLabel({required this.binding, this.style});
+  const new({required this.binding, this.style});
 
   @override
   Widget build(BuildContext context) {
@@ -115,7 +115,7 @@ class _KeybindCaptureDialog extends HookConsumerWidget {
   final ReaderKeyBinding currentValue;
   final ReaderKeyBinding defaultValue;
 
-  const _KeybindCaptureDialog({
+  const new({
     required this.title,
     required this.currentValue,
     required this.defaultValue,

--- a/test/pages/reader/overlay/reader_shortcuts_test.dart
+++ b/test/pages/reader/overlay/reader_shortcuts_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/pages/reader/overlay/reader_shortcuts.dart';
+import 'package:kover/riverpod/providers/platform.dart';
 import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
 import 'package:kover/utils/constants/platform_channels.dart';
 
@@ -34,6 +35,7 @@ void main() {
     }) async {
       final container = ProviderContainer.test(
         overrides: [
+          appPlatformProvider.overrideWithValue(AppPlatform.android),
           keybindsSettingsProvider.overrideWith(
             () => _FakeKeybindsSettings(settings),
           ),

--- a/test/pages/reader/overlay/reader_shortcuts_test.dart
+++ b/test/pages/reader/overlay/reader_shortcuts_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/pages/reader/overlay/reader_shortcuts.dart';
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+
+void main() {
+  group('ReaderShortcuts', () {
+    MockStreamHandlerEventSink? sink;
+    const channel = EventChannel('kover/volume_keys');
+
+    setUp(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(channel, _MockVolumeKeyHandler((eventSink) {
+            sink = eventSink;
+          }));
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(channel, null);
+    });
+
+    Future<void> pumpShortcuts(
+      WidgetTester tester, {
+      KeybindsSettingsState settings = const KeybindsSettingsState(),
+      void Function()? onNextPage,
+      void Function()? onPreviousPage,
+    }) async {
+      final container = ProviderContainer.test(
+        overrides: [
+          keybindsSettingsProvider.overrideWith(
+            () => _FakeKeybindsSettings(settings),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: ReaderShortcuts(
+            onNextPage: onNextPage,
+            onPreviousPage: onPreviousPage,
+            child: const SizedBox(),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('hardware keys dispatch through the same manager', (
+      tester,
+    ) async {
+      var next = 0;
+      var previous = 0;
+      await pumpShortcuts(
+        tester,
+        onNextPage: () => next++,
+        onPreviousPage: () => previous++,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+
+      expect(next, 1);
+      expect(previous, 1);
+    });
+
+    testWidgets('volume key stream dispatches through the manager', (
+      tester,
+    ) async {
+      var next = 0;
+      await pumpShortcuts(
+        tester,
+        settings: KeybindsSettingsState(
+          nextPageKey: ReaderKeyBinding(
+            id: LogicalKeyboardKey.audioVolumeUp.keyId,
+            keyLabel: LogicalKeyboardKey.audioVolumeUp.keyLabel,
+          ),
+        ),
+        onNextPage: () => next++,
+      );
+
+      await tester.runAsync(() async {
+        sink!.success(volumeUpKeyCode);
+        // Give the event stream + riverpod listener microtasks a chance to
+        // deliver through the real event loop.
+        await pumpEventQueue();
+      });
+      await tester.pump();
+
+      expect(next, 1);
+    });
+  });
+}
+
+class _FakeKeybindsSettings extends KeybindsSettings {
+  _FakeKeybindsSettings(this._settings);
+
+  final KeybindsSettingsState _settings;
+
+  @override
+  Future<KeybindsSettingsState> build() async => _settings;
+}
+
+class _MockVolumeKeyHandler extends MockStreamHandler {
+  _MockVolumeKeyHandler(this.onListenCallback);
+
+  final void Function(MockStreamHandlerEventSink events) onListenCallback;
+
+  @override
+  void onListen(Object? arguments, MockStreamHandlerEventSink events) {
+    onListenCallback(events);
+  }
+
+  @override
+  void onCancel(Object? arguments) {}
+}

--- a/test/pages/reader/overlay/reader_shortcuts_test.dart
+++ b/test/pages/reader/overlay/reader_shortcuts_test.dart
@@ -4,11 +4,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/pages/reader/overlay/reader_shortcuts.dart';
 import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+import 'package:kover/utils/constants/platform_channels.dart';
 
 void main() {
   group('ReaderShortcuts', () {
     MockStreamHandlerEventSink? sink;
-    const channel = EventChannel('kover/volume_keys');
+    const channel = PlatformChannels.volumeKeys;
 
     setUp(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/pages/reader/overlay/reader_shortcuts_test.dart
+++ b/test/pages/reader/overlay/reader_shortcuts_test.dart
@@ -12,9 +12,12 @@ void main() {
 
     setUp(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockStreamHandler(channel, _MockVolumeKeyHandler((eventSink) {
-            sink = eventSink;
-          }));
+          .setMockStreamHandler(
+            channel,
+            _MockVolumeKeyHandler((eventSink) {
+              sink = eventSink;
+            }),
+          );
     });
 
     tearDown(() {
@@ -85,8 +88,6 @@ void main() {
 
       await tester.runAsync(() async {
         sink!.success(volumeUpKeyCode);
-        // Give the event stream + riverpod listener microtasks a chance to
-        // deliver through the real event loop.
         await pumpEventQueue();
       });
       await tester.pump();

--- a/test/riverpod/providers/settings/keybinds_settings_test.dart
+++ b/test/riverpod/providers/settings/keybinds_settings_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/riverpod/providers/platform.dart';
 import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
 import 'package:kover/utils/constants/platform_channels.dart';
 
@@ -116,6 +117,7 @@ void main() {
 
       final container = ProviderContainer.test(
         overrides: [
+          appPlatformProvider.overrideWithValue(AppPlatform.android),
           keybindsSettingsProvider.overrideWith(
             () => _FakeKeybindsSettings(const KeybindsSettingsState()),
           ),

--- a/test/riverpod/providers/settings/keybinds_settings_test.dart
+++ b/test/riverpod/providers/settings/keybinds_settings_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+import 'package:kover/utils/constants/platform_channels.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -99,7 +100,7 @@ void main() {
   group('volume keys', () {
     test('emits every press, including repeats of the same key', () async {
       MockStreamHandlerEventSink? sink;
-      const channel = EventChannel('kover/volume_keys');
+      const channel = PlatformChannels.volumeKeys;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockStreamHandler(
             channel,
@@ -113,7 +114,13 @@ void main() {
             .setMockStreamHandler(channel, null),
       );
 
-      final container = ProviderContainer.test();
+      final container = ProviderContainer.test(
+        overrides: [
+          keybindsSettingsProvider.overrideWith(
+            () => _FakeKeybindsSettings(const KeybindsSettingsState()),
+          ),
+        ],
+      );
       addTearDown(container.dispose);
 
       final events = <LogicalKeyboardKey>[];
@@ -121,6 +128,7 @@ void main() {
         volumeKeysProvider(),
         (previous, next) => next.whenData((event) => events.add(event.key)),
       );
+      await pumpEventQueue();
 
       sink!.success(volumeUpKeyCode);
       sink!.success(volumeUpKeyCode);
@@ -132,6 +140,15 @@ void main() {
       ]);
     });
   });
+}
+
+class _FakeKeybindsSettings extends KeybindsSettings {
+  _FakeKeybindsSettings(this._settings);
+
+  final KeybindsSettingsState _settings;
+
+  @override
+  Future<KeybindsSettingsState> build() async => _settings;
 }
 
 class _MockVolumeKeyHandler extends MockStreamHandler {

--- a/test/riverpod/providers/settings/keybinds_settings_test.dart
+++ b/test/riverpod/providers/settings/keybinds_settings_test.dart
@@ -96,67 +96,7 @@ void main() {
     });
   });
 
-  group('KeybindsSettingsState', () {
-    test('defaults use arrow keys', () {
-      const state = KeybindsSettingsState();
-
-      expect(state.nextPage, KeybindsSettingsState.defaultNextPage);
-      expect(state.previousPage, KeybindsSettingsState.defaultPreviousPage);
-      expect(
-        state.nextPage.activator?.triggers.single,
-        LogicalKeyboardKey.arrowRight,
-      );
-      expect(
-        state.previousPage.activator?.triggers.single,
-        LogicalKeyboardKey.arrowLeft,
-      );
-    });
-
-    test('explicit bindings override defaults', () {
-      const pageDown = ReaderKeyBinding(id: 9999, keyLabel: 'Page Down');
-      const state = KeybindsSettingsState(nextPageKey: pageDown);
-
-      expect(state.nextPage, pageDown);
-    });
-
-    test('assigned contains both resolved bindings', () {
-      const pageDown = ReaderKeyBinding(id: 9999, keyLabel: 'Page Down');
-      const state = KeybindsSettingsState(previousPageKey: pageDown);
-
-      expect(state.assigned, {
-        KeybindsSettingsState.defaultNextPage,
-        pageDown,
-      });
-    });
-  });
-
   group('volume keys', () {
-    test('keycode mapping round trips', () {
-      expect(
-        volumeKeyCodeFor(LogicalKeyboardKey.audioVolumeUp),
-        volumeUpKeyCode,
-      );
-      expect(
-        volumeKeyCodeFor(LogicalKeyboardKey.audioVolumeDown),
-        volumeDownKeyCode,
-      );
-      expect(volumeKeyCodeFor(LogicalKeyboardKey.keyA), isNull);
-
-      expect(
-        logicalKeyForVolumeKeyCode(volumeUpKeyCode),
-        LogicalKeyboardKey.audioVolumeUp,
-      );
-      expect(
-        logicalKeyForVolumeKeyCode(volumeDownKeyCode),
-        LogicalKeyboardKey.audioVolumeDown,
-      );
-      expect(logicalKeyForVolumeKeyCode(-1), isNull);
-
-      for (final key in capturableVolumeKeys) {
-        expect(volumeKeyCodeFor(key), isNotNull);
-      }
-    });
-
     test('emits every press, including repeats of the same key', () async {
       MockStreamHandlerEventSink? sink;
       const channel = EventChannel('kover/volume_keys');
@@ -178,7 +118,7 @@ void main() {
 
       final events = <LogicalKeyboardKey>[];
       container.listen(
-        volumeKeysProvider,
+        volumeKeysProvider(),
         (previous, next) => next.whenData((event) => events.add(event.key)),
       );
 

--- a/test/riverpod/providers/settings/keybinds_settings_test.dart
+++ b/test/riverpod/providers/settings/keybinds_settings_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kover/riverpod/providers/settings/keybinds_settings.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ReaderKeyBinding', () {
+    test('json round trip preserves all fields', () {
+      final binding = ReaderKeyBinding(
+        id: LogicalKeyboardKey.arrowRight.keyId,
+        keyLabel: LogicalKeyboardKey.arrowRight.keyLabel,
+        control: true,
+      );
+
+      final result = ReaderKeyBinding.fromJson(binding.toJson());
+
+      expect(result, binding);
+      expect(result.control, isTrue);
+    });
+
+    test('activator resolves known keys with modifiers', () {
+      final activator = ReaderKeyBinding(
+        id: LogicalKeyboardKey.pageDown.keyId,
+        keyLabel: LogicalKeyboardKey.pageDown.keyLabel,
+        shift: true,
+      ).activator;
+
+      expect(activator?.triggers.single, LogicalKeyboardKey.pageDown);
+      expect(activator?.shift, isTrue);
+      expect(activator?.control, isFalse);
+    });
+
+    test('activator returns null for unknown keys', () {
+      expect(const ReaderKeyBinding(id: -1, keyLabel: '?').activator, isNull);
+    });
+
+    test('label prefixes modifiers onto the stored key label', () {
+      final arrowRight = LogicalKeyboardKey.arrowRight;
+      final keyA = LogicalKeyboardKey.keyA;
+
+      expect(
+        ReaderKeyBinding(
+          id: arrowRight.keyId,
+          keyLabel: arrowRight.keyLabel,
+        ).label,
+        'Arrow Right',
+      );
+      expect(
+        ReaderKeyBinding(
+          id: keyA.keyId,
+          keyLabel: keyA.keyLabel,
+          control: true,
+        ).label,
+        'Ctrl + A',
+      );
+      expect(
+        const ReaderKeyBinding(id: 1, keyLabel: 'Digit1', alt: true).label,
+        'Alt + Digit1',
+      );
+    });
+
+    test('isVolumeKey identifies volume keys', () {
+      expect(
+        ReaderKeyBinding(
+          id: LogicalKeyboardKey.audioVolumeUp.keyId,
+          keyLabel: LogicalKeyboardKey.audioVolumeUp.keyLabel,
+        ).isVolumeKey,
+        isTrue,
+      );
+      expect(
+        ReaderKeyBinding(
+          id: LogicalKeyboardKey.audioVolumeDown.keyId,
+          keyLabel: LogicalKeyboardKey.audioVolumeDown.keyLabel,
+        ).isVolumeKey,
+        isTrue,
+      );
+      expect(
+        ReaderKeyBinding(
+          id: LogicalKeyboardKey.keyA.keyId,
+          keyLabel: LogicalKeyboardKey.keyA.keyLabel,
+        ).isVolumeKey,
+        isFalse,
+      );
+    });
+
+    test('key getter resolves the logical key by id', () {
+      expect(
+        ReaderKeyBinding(
+          id: LogicalKeyboardKey.escape.keyId,
+          keyLabel: LogicalKeyboardKey.escape.keyLabel,
+        ).key,
+        LogicalKeyboardKey.escape,
+      );
+    });
+  });
+
+  group('KeybindsSettingsState', () {
+    test('defaults use arrow keys', () {
+      const state = KeybindsSettingsState();
+
+      expect(state.nextPage, KeybindsSettingsState.defaultNextPage);
+      expect(state.previousPage, KeybindsSettingsState.defaultPreviousPage);
+      expect(
+        state.nextPage.activator?.triggers.single,
+        LogicalKeyboardKey.arrowRight,
+      );
+      expect(
+        state.previousPage.activator?.triggers.single,
+        LogicalKeyboardKey.arrowLeft,
+      );
+    });
+
+    test('explicit bindings override defaults', () {
+      const pageDown = ReaderKeyBinding(id: 9999, keyLabel: 'Page Down');
+      const state = KeybindsSettingsState(nextPageKey: pageDown);
+
+      expect(state.nextPage, pageDown);
+    });
+
+    test('assigned contains both resolved bindings', () {
+      const pageDown = ReaderKeyBinding(id: 9999, keyLabel: 'Page Down');
+      const state = KeybindsSettingsState(previousPageKey: pageDown);
+
+      expect(state.assigned, {
+        KeybindsSettingsState.defaultNextPage,
+        pageDown,
+      });
+    });
+  });
+
+  group('volume keys', () {
+    test('keycode mapping round trips', () {
+      expect(
+        volumeKeyCodeFor(LogicalKeyboardKey.audioVolumeUp),
+        volumeUpKeyCode,
+      );
+      expect(
+        volumeKeyCodeFor(LogicalKeyboardKey.audioVolumeDown),
+        volumeDownKeyCode,
+      );
+      expect(volumeKeyCodeFor(LogicalKeyboardKey.keyA), isNull);
+
+      expect(
+        logicalKeyForVolumeKeyCode(volumeUpKeyCode),
+        LogicalKeyboardKey.audioVolumeUp,
+      );
+      expect(
+        logicalKeyForVolumeKeyCode(volumeDownKeyCode),
+        LogicalKeyboardKey.audioVolumeDown,
+      );
+      expect(logicalKeyForVolumeKeyCode(-1), isNull);
+
+      for (final key in capturableVolumeKeys) {
+        expect(volumeKeyCodeFor(key), isNotNull);
+      }
+    });
+
+    test('emits every press, including repeats of the same key', () async {
+      MockStreamHandlerEventSink? sink;
+      const channel = EventChannel('kover/volume_keys');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+            channel,
+            _MockVolumeKeyHandler((eventSink) {
+              sink = eventSink;
+            }),
+          );
+
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockStreamHandler(channel, null),
+      );
+
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      final events = <LogicalKeyboardKey>[];
+      container.listen(
+        volumeKeysProvider,
+        (previous, next) => next.whenData((event) => events.add(event.key)),
+      );
+
+      sink!.success(volumeUpKeyCode);
+      sink!.success(volumeUpKeyCode);
+      await pumpEventQueue();
+
+      expect(events, [
+        LogicalKeyboardKey.audioVolumeUp,
+        LogicalKeyboardKey.audioVolumeUp,
+      ]);
+    });
+  });
+}
+
+class _MockVolumeKeyHandler extends MockStreamHandler {
+  _MockVolumeKeyHandler(this.onListenCallback);
+
+  final void Function(MockStreamHandlerEventSink events) onListenCallback;
+
+  @override
+  void onListen(Object? arguments, MockStreamHandlerEventSink events) {
+    onListenCallback(events);
+  }
+
+  @override
+  void onCancel(Object? arguments) {}
+}


### PR DESCRIPTION
Add support for configuring the reader next/previous page keybinds, including volume keys on android.

closes #354